### PR TITLE
Add logging config and add logging to templater and fuzzy matching

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -1,14 +1,18 @@
 from pathlib import Path
+
 import yaml
 
 from ispypsa.data_fetch.local_cache import REQUIRED_TABLES, build_local_cache
-from ispypsa.templater.nodes import template_nodes
+from ispypsa.logging import configure_logging
 from ispypsa.templater.flow_paths import template_flow_paths
 from ispypsa.templater.generators import _template_ecaa_generators
+from ispypsa.templater.nodes import template_nodes
 
 _PARSED_WORKBOOK_CACHE = Path("model_inputs", "workbook_table_cache")
 _TEMPLATE_DIRECTORY = Path("model_inputs", "template")
 _CONFIG_PATH = Path("model_inputs", "ispypsa_config.yaml")
+
+configure_logging()
 
 
 def build_parsed_workbook_cache(cache_location: Path) -> None:

--- a/src/ispypsa/__init__.py
+++ b/src/ispypsa/__init__.py
@@ -1,13 +1,4 @@
-import logging
-import sys
-
 import pandas as pd
-
-# logging configuration
-logging.getLogger(__name__).addHandler(logging.NullHandler())
-logging.basicConfig(
-    stream=sys.stdout, level=logging.INFO, format="%(levelname)s: %(message)s"
-)
 
 # pandas options
 pd.set_option("future.no_silent_downcasting", True)

--- a/src/ispypsa/logging.py
+++ b/src/ispypsa/logging.py
@@ -1,0 +1,42 @@
+import logging
+import sys
+
+
+def configure_logging(
+    console: bool = True,
+    console_level: int = logging.WARNING,
+    file: bool = True,
+    file_level: int = logging.INFO,
+    log_file: str = "ISPyPSA.log",
+) -> None:
+    """Configures ISPyPSA logging
+
+    Args:
+        console: Whether to log to the console. Defaults to True.
+        console_level: Level of the console logging. Defaults to logging.WARNING.
+        file: Whether to log to a log file. Defaults to True.
+        file_level: Level of the file logging. Defaults to logging.INFO.
+        log_file: Name of the logging file. Defaults to "ISPyPSA.log".
+    """
+    for handler in logging.root.handlers[:]:
+        logging.root.removeHandler(handler)
+    handlers = []
+    if console:
+        console_handler = logging.StreamHandler(stream=sys.stdout)
+        console_handler.setLevel(console_level)
+        console_formatter = logging.Formatter("%(levelname)s: %(message)s")
+        console_handler.setFormatter(console_formatter)
+        handlers.append(console_handler)
+    if file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(file_level)
+        file_formatter = logging.Formatter("%(asctime)s - %(levelname)s: %(message)s")
+        file_handler.setFormatter(file_formatter)
+        handlers.append(file_handler)
+    if not handlers:
+        handlers.append(logging.NullHandler())
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(levelname)s: %(message)s",
+        handlers=handlers,
+    )

--- a/src/ispypsa/templater/flow_paths.py
+++ b/src/ispypsa/templater/flow_paths.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from pathlib import Path
 
@@ -27,6 +28,7 @@ def template_flow_paths(
     Returns:
         `pd.DataFrame`: ISPyPSA flow path template
     """
+    logging.info(f"Creating a flow paths template with {granularity} granularity")
     validate_granularity(granularity)
     if granularity == "sub_regional":
         template = _template_sub_regional_flow_paths(parsed_workbook_path)

--- a/src/ispypsa/templater/generators.py
+++ b/src/ispypsa/templater/generators.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from pathlib import Path
 
@@ -8,8 +9,8 @@ from .helpers import (
     _snakecase_string,
     _where_any_substring_appears,
 )
-from .mappings import _ECAA_GENERATOR_STATIC_PROPERTY_TABLE_MAP
 from .lists import _ECAA_GENERATOR_TYPES
+from .mappings import _ECAA_GENERATOR_STATIC_PROPERTY_TABLE_MAP
 
 _OBSOLETE_COLUMNS = [
     "Maximum capacity factor (%)",
@@ -29,6 +30,9 @@ def _template_ecaa_generators(
     Returns:
         `pd.DataFrame`: ISPyPSA ECAA generators template
     """
+    logging.info(
+        "Creating an existing, committed, anticipated and additional generators template"
+    )
     ecaa_generator_summaries = []
     for gen_type in _ECAA_GENERATOR_TYPES:
         df = pd.read_csv(

--- a/src/ispypsa/templater/generators.py
+++ b/src/ispypsa/templater/generators.py
@@ -166,10 +166,13 @@ def _merge_csv_data(
     # handles differences of mapping values between summmary and outage tables
     if re.search("outage", col):
         df[col] = _rename_summary_outage_mappings(df[col])
-    # handles slight difference in capitalisation e.g. Bongong/Mackay vs Bogong/MacKay
+    # handles slight difference in capitalisation e.g. Bogong/Mackay vs Bogong/MacKay
     where_str = df[col].apply(lambda x: isinstance(x, str))
     df.loc[where_str, col] = _fuzzy_match_names_above_threshold(
-        df.loc[where_str, col], replacement_dict.keys(), 99
+        df.loc[where_str, col],
+        replacement_dict.keys(),
+        99,
+        "merging in existing, committed, anticipated and additional generator static properties",
     )
     df[col] = df[col].replace(replacement_dict)
     if "new_col_name" in csv_attrs.keys():

--- a/src/ispypsa/templater/nodes.py
+++ b/src/ispypsa/templater/nodes.py
@@ -30,6 +30,7 @@ def template_nodes(
     Returns:
         `pd.DataFrame`: ISPyPSA node template
     """
+    logging.info(f"Creating a nodes template with {granularity} granularity")
     validate_granularity(granularity)
     if granularity == "sub_regional":
         template = _template_sub_regional_node_table(parsed_workbook_path)
@@ -203,7 +204,7 @@ def _request_transmission_substation_coordinates() -> pd.DataFrame:
     url = "https://services.ga.gov.au/gis/services/Foundation_Electricity_Infrastructure/MapServer/WFSServer"
     substation_coordinates = {}
     try:
-        r = requests.get(url, params=params)
+        r = requests.get(url, params=params, timeout=30)
         if r.status_code == 200:
             data = xmltodict.parse(r.content)
             features = data["wfs:FeatureCollection"]["wfs:member"]

--- a/src/ispypsa/templater/nodes.py
+++ b/src/ispypsa/templater/nodes.py
@@ -56,7 +56,9 @@ def template_nodes(
     if not substation_coordinates.empty:
         reference_node_col = process.extractOne("reference_node", template.columns)[0]
         matched_subs = _fuzzy_match_names(
-            template[reference_node_col], substation_coordinates.index
+            template[reference_node_col],
+            substation_coordinates.index,
+            "merging in substation coordinate data",
         )
         reference_node_coordinates = pd.merge(
             matched_subs,
@@ -119,7 +121,9 @@ def _template_sub_regional_node_table(
         axis=1,
     )
     sub_regional_nodes["nem_region"] = _fuzzy_match_names(
-        sub_regional_nodes["nem_region"], _NEM_REGION_IDS.keys()
+        sub_regional_nodes["nem_region"],
+        _NEM_REGION_IDS.keys(),
+        "determining the NEM region",
     )
     sub_regional_nodes["nem_region_id"] = sub_regional_nodes["nem_region"].replace(
         _NEM_REGION_IDS
@@ -169,7 +173,9 @@ def _template_regional_node_table(
         axis=1,
     )
     regional_nodes["nem_region"] = _fuzzy_match_names(
-        regional_nodes["nem_region"], _NEM_REGION_IDS.keys()
+        regional_nodes["nem_region"],
+        _NEM_REGION_IDS.keys(),
+        "determining the NEM region",
     )
     regional_nodes["nem_region_id"] = regional_nodes["nem_region"].replace(
         _NEM_REGION_IDS
@@ -204,7 +210,7 @@ def _request_transmission_substation_coordinates() -> pd.DataFrame:
     url = "https://services.ga.gov.au/gis/services/Foundation_Electricity_Infrastructure/MapServer/WFSServer"
     substation_coordinates = {}
     try:
-        r = requests.get(url, params=params, timeout=30)
+        r = requests.get(url, params=params, timeout=60)
         if r.status_code == 200:
             data = xmltodict.parse(r.content)
             features = data["wfs:FeatureCollection"]["wfs:member"]

--- a/tests/templater/test_helpers.py
+++ b/tests/templater/test_helpers.py
@@ -17,7 +17,7 @@ def test_fuzzy_matching() -> None:
     expected = pd.Series(
         ["New South Wales", "Queensland", "South Australia", "Victoria", "Tasmania"]
     )
-    test_results = _fuzzy_match_names(region_typos, _NEM_REGION_IDS.keys())
+    test_results = _fuzzy_match_names(region_typos, _NEM_REGION_IDS.keys(), "testing")
     assert (test_results == expected).all()
 
 
@@ -26,9 +26,7 @@ def test_fuzzy_matching_above_threshold() -> None:
         ["New South Walks", "Coinsland", "North Australia", "Bigtoria", "Radmania"]
     )
     test_results = _fuzzy_match_names_above_threshold(
-        region_typos,
-        _NEM_REGION_IDS.keys(),
-        70,
+        region_typos, _NEM_REGION_IDS.keys(), 70, "testing"
     )
     assert (
         test_results
@@ -47,7 +45,7 @@ def test_fuzzy_matching_above_threshold_replace() -> None:
         ["New South Walks", "Coinsland", "North Australia", "Bigtoria", "Radmania"]
     )
     test_results = _fuzzy_match_names_above_threshold(
-        region_typos, _NEM_REGION_IDS.keys(), 70, not_match="replacement"
+        region_typos, _NEM_REGION_IDS.keys(), 70, "testing", not_match="replacement"
     )
     assert (
         test_results


### PR DESCRIPTION
- Uses a `configure_logging()` function in `logging.py` to:
  - Disable/configure a logging level for the console/terminal
  - Disable/configure a logging level for the log file
  - Default warning for console, info for file
- Info logging for templater functions
- Info logging functionality added to fuzzy matching:
  - Will give name of original and match
  - Uses a custom task description
    - fuzzy matching is not just used for merging tables in

Example output in ISPyPSA.log:
![image](https://github.com/user-attachments/assets/8b320b5a-6d6d-4bec-bc2c-a25532dd28df)
  
Closes #3 