### PR TITLE
Refactor network granularity and some other minor changes

### DIFF
--- a/model_data/ispypsa_inputs/ispypsa_config.yaml
+++ b/model_data/ispypsa_inputs/ispypsa_config.yaml
@@ -7,14 +7,19 @@
 #   "Green Energy Exports": Sees very strong industrial decarbonisation and low-emission energy exports
 scenario: Step Change
 network:
-  # The geographical granularity of the modelled network (i.e. the number of network nodes)
-  # Options:
-  #   "sub_regional": ISP Sub-regions are used to create network nodes (12 nodes)
-  #   "regional": NEM regions are used to create network nodes (5 nodes)
-  #   "single_region": Existing generation and new entrants for the Victorian sub-region are attached to a single node (1 node)
-  #   TODO: Clarify `single_region`/`copper_plate` implementation
-  granularity: sub_regional
-
+  nodes:
+    # The regional granularity of the nodes in the modelled network
+    # Options:
+    #   "sub_regions": ISP sub-regions are added as network nodes (12 nodes)
+    #   "nem_regions": NEM regions are added as network nodes (5 nodes)
+    #   "single_region": A single node, the Victorian sub-region, is added as a network node (1 node)
+    #   TODO: Clarify `single_region`/`copper_plate` implementation
+    regional_granularity: sub_regions
+    # Whether Renewable Energy Zones (REZs) are modelled as distinct nodes
+    # Options:
+    #   "discrete_nodes": REZs are added as network nodes to model REZ transmission limits
+    #   "attached_to_parent_node": REZ resources are attached to their parent node (sub-region or NEM region)
+    rezs: discrete_nodes
 traces:
   year_type: fy
   start_year: 2025

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -5,8 +5,13 @@ from pydantic import BaseModel, field_validator
 from ..templater.lists import _ISP_SCENARIOS
 
 
+class NodesConfig(BaseModel):
+    regional_granularity: Literal["sub_regions", "nem_regions", "single_region"]
+    rezs: Literal["discrete_nodes", "attached_to_parent_node"]
+
+
 class NetworkConfig(BaseModel):
-    granularity: Literal["sub_regional", "regional", "single_region"]
+    nodes: NodesConfig
 
 
 class TraceConfig(BaseModel):

--- a/src/ispypsa/templater/nodes.py
+++ b/src/ispypsa/templater/nodes.py
@@ -116,7 +116,7 @@ def template_sub_regions_to_nem_regions_mapping(
     return mapping
 
 
-def template_region_to_single_sub_region(
+def template_region_to_single_sub_region_mapping(
     parsed_workbook_path: Path | str,
 ) -> pd.DataFrame:
     """Processes the 'Regional reference node' table into an ISPyPSA template

--- a/src/ispypsa/templater/nodes.py
+++ b/src/ispypsa/templater/nodes.py
@@ -116,7 +116,7 @@ def template_sub_regions_to_nem_regions_mapping(
     return mapping
 
 
-def template_region_to_single_sub_region_mapping(
+def template_nem_region_to_single_sub_region_mapping(
     parsed_workbook_path: Path | str,
 ) -> pd.DataFrame:
     """Processes the 'Regional reference node' table into an ISPyPSA template

--- a/src/ispypsa/templater/nodes.py
+++ b/src/ispypsa/templater/nodes.py
@@ -14,31 +14,32 @@ from .mappings import _NEM_REGION_IDS, _NEM_SUB_REGION_IDS
 
 
 def template_nodes(
-    parsed_workbook_path: Path | str, granularity: str = "sub_regional"
+    parsed_workbook_path: Path | str,
+    regional_granularity: str = "sub_regions",
+    rez_nodes: str = "discrete_nodes",
 ) -> pd.DataFrame:
     """Creates a node template that describes the nodes (i.e. buses) to be modelled
-
-    The function behaviour depends on the `granularity` specified in the model
-    configuration.
 
     Args:
         parsed_workbook_path: Path to directory with table CSVs that are the
             outputs from the `isp-workbook-parser`.
-        granularity: Geographical granularity obtained from the model configuration.
-            Defaults to "sub_regional".
+        regional_granularity: Regional granularity of the nodes obtained from the model
+            configuration. Defaults to "sub_regions".
+        rez_nodes: How Renewable Energy Zones are modelled in the network. Obtainee from
+            the model configuration. Defaults to "discrete_nodes".
 
     Returns:
         `pd.DataFrame`: ISPyPSA node template
     """
-    logging.info(f"Creating a nodes template with {granularity} granularity")
-    if granularity == "sub_regional":
+    logging.info(f"Creating a nodes template with {regional_granularity} as nodes")
+    if regional_granularity == "sub_regions":
         template = _template_sub_regional_node_table(parsed_workbook_path)
-        index_col = "isp_sub_region_id"
-    elif granularity == "regional":
+        index_col = "id"
+    elif regional_granularity == "nem_regions":
         template = _template_regional_node_table(parsed_workbook_path)
         index_col = "nem_region_id"
 
-    elif granularity == "single_region":
+    elif regional_granularity == "single_region":
         # TODO: Clarify `single_region`/`copper_plate` implementation
         template = {
             "isp_sub_region_id": "VIC",
@@ -58,6 +59,7 @@ def template_nodes(
             template[reference_node_col],
             substation_coordinates.index,
             "merging in substation coordinate data",
+            threshold=85,
         )
         reference_node_coordinates = pd.merge(
             matched_subs,
@@ -78,9 +80,9 @@ def template_nodes(
     return template
 
 
-def template_regional_sub_regional_mapping(parsed_workbook_path: Path | str):
-    """Processes the 'Sub-regional network representation' table into an ISPyPSA template format that maps Sub-region
-    IDs to NEM region IDs.
+def template_sub_regions_to_nem_regions_mapping(parsed_workbook_path: Path | str):
+    """Processes the 'Sub-regional network representation' table into an ISPyPSA template
+    format that maps sub-region IDs to NEM region IDs.
 
     Args:
         parsed_workbook_path: Path to directory containing CSVs that are the output
@@ -90,24 +92,58 @@ def template_regional_sub_regional_mapping(parsed_workbook_path: Path | str):
         `pd.DataFrame`: ISPyPSA regional to subregional mapping template
 
     """
-    regional_sub_regional_mapping = _template_sub_regional_node_table(
-        parsed_workbook_path
+    sub_regions = pd.read_csv(
+        Path(parsed_workbook_path, "sub_regional_reference_nodes.csv")
     )
-    regional_sub_regional_mapping.index = (
-        regional_sub_regional_mapping["nem_region_id"].copy(deep=True).rename("node_id")
+    sub_region_name_and_id = _split_out_sub_region_name_and_id(sub_regions)
+    sub_regions = pd.concat(
+        [
+            sub_region_name_and_id["isp_sub_region_id"],
+            sub_regions["NEM Region"].rename("nem_region"),
+        ],
+        axis=1,
     )
-    return regional_sub_regional_mapping.loc[:, ["isp_sub_region_id"]]
+    mapping = _match_region_name_and_id(sub_regions)
+    mapping = mapping.drop(columns=["nem_region"]).set_index("isp_sub_region_id")
+    return mapping
 
 
-def _template_sub_regional_node_table(
+def template_region_to_single_sub_region(
     parsed_workbook_path: Path | str,
 ) -> pd.DataFrame:
-    """Processes the 'Sub-regional network representation' table into an ISPyPSA template format
+    """Processes the 'Regional reference node' table into an ISPyPSA template
+    format that maps each NEM region to a single sub-region that corresponds to the
+    sub-region of the RRN.
 
     Args:
         parsed_workbook_path: Path to directory containing CSVs that are the output
             of parsing an ISP Inputs and Assumptions workbook using `isp-workbook-parser`
 
+    Returns:
+        pd.DataFrame: ISPyPSA region to single sub-region mapping template
+    """
+    regional_df = pd.read_csv(
+        Path(parsed_workbook_path, "regional_reference_nodes.csv")
+    )
+    sub_region_name_and_id = _split_out_sub_region_name_and_id(regional_df)
+    mapping = pd.concat(
+        [
+            regional_df["NEM Region"].rename("nem_region"),
+            sub_region_name_and_id["isp_sub_region_id"],
+        ],
+        axis=1,
+    )
+    mapping = _match_region_name_and_id(mapping).drop(columns=["nem_region"])
+    mapping = mapping.set_index("nem_region_id")
+    return mapping
+
+
+def _template_sub_regional_node_table(parsed_workbook_path: Path | str) -> pd.DataFrame:
+    """Processes the 'Sub-regional network representation' table into an ISPyPSA template format
+
+    Args:
+        parsed_workbook_path: Path to directory containing CSVs that are the output
+            of parsing an ISP Inputs and Assumptions workbook using `isp-workbook-parser`
     Returns:
         `pd.DataFrame`: ISPyPSA sub-regional node template
 
@@ -118,16 +154,15 @@ def _template_sub_regional_node_table(
     sub_region_name_and_id = _split_out_sub_region_name_and_id(sub_regional_df)
     node_voltage_col = "Sub-region Reference Node"
     split_node_voltage = _extract_voltage(sub_regional_df, node_voltage_col)
-    sub_regional_nodes = pd.concat(
+    sub_regions = pd.concat(
         [
             sub_region_name_and_id,
             split_node_voltage,
-            sub_regional_df["NEM Region"].rename("nem_region"),
         ],
         axis=1,
     )
-    sub_regional_nodes = _match_region_name_and_id(sub_regional_nodes)
-    return sub_regional_nodes
+    sub_regions = sub_regions.rename(columns={"isp_sub_region": "name"})
+    return sub_regions
 
 
 def _template_regional_node_table(
@@ -149,7 +184,7 @@ def _template_regional_node_table(
     sub_region_name_and_id = _split_out_sub_region_name_and_id(regional_df)
     node_voltage_col = "Regional Reference Node"
     split_node_voltage = _extract_voltage(regional_df, node_voltage_col)
-    regional_nodes = pd.concat(
+    regions = pd.concat(
         [
             regional_df["NEM Region"].rename("nem_region"),
             sub_region_name_and_id,
@@ -157,8 +192,9 @@ def _template_regional_node_table(
         ],
         axis=1,
     )
-    regional_nodes = _match_region_name_and_id(regional_nodes)
-    return regional_nodes
+    regions = _match_region_name_and_id(regions)
+    regions = regions.rename(columns={"nem_region": "name"})
+    return regions
 
 
 def _split_out_sub_region_name_and_id(data: pd.DataFrame):
@@ -255,18 +291,11 @@ def _request_transmission_substation_coordinates() -> pd.DataFrame:
             "Could not get substation coordinate data. "
             + "Network node data will be templated without coordinate data."
         )
-    return pd.DataFrame(substation_coordinates).T
-
-
-def _split_name_id(series: pd.Series) -> pd.DataFrame:
-    """
-    Capture the name (plain English) and ID in parentheses (capitalised letters)
-    using a regular expression on a string `pandas.Series`.
-    """
-    split_name_id = series.str.strip().str.extract(
-        r"(?P<name>[A-Za-z\s,]+)\s\((?P<id>[A-Z]+)\)", expand=True
-    )
-    return split_name_id
+    substation_coordinates = pd.DataFrame(substation_coordinates).T
+    substation_coordinates = substation_coordinates[
+        substation_coordinates.index.notna()
+    ]
+    return substation_coordinates
 
 
 def _capture_just_name(series: pd.Series) -> pd.DataFrame:

--- a/src/ispypsa/templater/renewable_energy_zones.py
+++ b/src/ispypsa/templater/renewable_energy_zones.py
@@ -3,32 +3,47 @@ from pathlib import Path
 
 import pandas as pd
 
+from .helpers import _snakecase_string
 
-def template_renewable_energy_zone_locations(
-    parsed_workbook_path: Path | str,
+
+def template_renewable_energy_zones(
+    parsed_workbook_path: Path | str, location_mapping_only: bool = True
 ) -> pd.DataFrame:
     """Creates a mapping table that specifies which regions and sub regions renewable energy zones belong to.
 
     Args:
         parsed_workbook_path: Path to directory with table CSVs that are the
             outputs from the `isp-workbook-parser`.
+        location_mapping_only: Whether to create a location mapping template that only
+            contains columns that map REZ IDs to sub-regions and regions.
+            Defaults to True.
 
     Returns:
         `pd.DataFrame`: ISPyPSA region and zone mapping table
     """
     logging.info("Creating a renewable_energy_zone_locations template")
-    renewable_energy_zone_locations = pd.read_csv(
+    renewable_energy_zones = pd.read_csv(
         Path(parsed_workbook_path, "renewable_energy_zones.csv")
     )
-    renewable_energy_zone_locations = renewable_energy_zone_locations.loc[
-        :, ["NEM Region", "ISP Sub-region", "ID"]
+    renewable_energy_zones.columns = [
+        _snakecase_string(col_name) for col_name in renewable_energy_zones.columns
     ]
-    renewable_energy_zone_locations.columns = [
-        "nem_region_id",
-        "isp_sub_region_id",
-        "rez_id",
-    ]
-    renewable_energy_zone_locations = renewable_energy_zone_locations.set_index(
-        "rez_id", drop=True
+    renewable_energy_zones = renewable_energy_zones.rename(
+        columns={
+            "nem_region": "nem_region_id",
+            "isp_sub_region": "isp_sub_region_id",
+            "id": "rez_id",
+        }
     )
-    return renewable_energy_zone_locations
+    if location_mapping_only:
+        renewable_energy_zones = renewable_energy_zones.loc[
+            :,
+            [
+                "name",
+                "nem_region_id",
+                "isp_sub_region_id",
+                "rez_id",
+            ],
+        ]
+    renewable_energy_zones = renewable_energy_zones.set_index("rez_id", drop=True)
+    return renewable_energy_zones

--- a/src/ispypsa/translator/buses.py
+++ b/src/ispypsa/translator/buses.py
@@ -26,24 +26,27 @@ def _translate_nodes_to_buses(ispypsa_inputs_path: Path | str) -> pd.DataFrame:
     return buses
 
 
-def _translate_buses_timeseries(
+def _translate_buses_demand_timeseries(
     ispypsa_inputs_path: Path | str,
     trace_data_path: Path | str,
     pypsa_inputs_path: Path | str,
     scenario: str,
-    granularity: str,
+    regional_granularity: str,
     reference_year_mapping: dict[int:int],
     year_type: Literal["fy", "calendar"],
 ) -> None:
-    """Gets trace data for operational demand by constructing a timeseries from the start to end year using the
-    eference year cycle provided. Trace data is then saved as a parquet file to .
+    """Gets trace data for operational demand by constructing a timeseries from the
+    start to end year using the reference year cycle provided.
+
+    Trace data is then saved as a parquet file to `pypsa_inputs_path`.
 
     Args:
         ispypsa_inputs_path: Path to directory containing modelling input template CSVs.
         trace_data_path: Path to directory containing trace data parsed by isp-trace-parser
         pypsa_inputs_path: Path to director where input translated to pypsa format will be saved
         scenario: str, ISP scenario to use demand traces from
-        granularity: Geographical granularity obtained from the model configuration
+        regional_granularity: Regional granularity of the nodes obtained from the model
+            configuration. Defaults to "sub_regions".
         reference_year_mapping: dict[int: int], mapping model years to trace data reference years
         year_type: str, 'fy' or 'calendar', if 'fy' then time filtering is by financial year with start_year and
             end_year specifiying the financial year to return data for, using year ending nomenclature (2016 ->
@@ -52,37 +55,57 @@ def _translate_buses_timeseries(
     Returns:
         None
     """
-    if granularity == "regional":
-        region_mapping = pd.read_csv(
-            ispypsa_inputs_path / Path("regional_sub_regional_mapping.csv")
-        )
-
-    elif granularity == "sub_regional":
-        region_mapping = pd.read_csv(ispypsa_inputs_path / Path("nodes.csv"))
-
     trace_data_path = trace_data_path / Path("demand")
-
     output_trace_path = Path(pypsa_inputs_path, "demand_traces")
-
     if not output_trace_path.exists():
         output_trace_path.mkdir(parents=True)
 
-    for node in region_mapping["node_id"]:
-        sub_regions_under_node = region_mapping[region_mapping["node_id"] == node][
-            "isp_sub_region_id"
-        ]
+    all_nodes = pd.read_csv(ispypsa_inputs_path / Path("nodes.csv"))
+    # remove "s" unless single_region for for type filtering
+    if regional_granularity != "single_region":
+        demand_node_type = regional_granularity[:-1]
+    else:
+        demand_node_type = regional_granularity
+    demand_nodes = all_nodes.loc[all_nodes["type"] == demand_node_type]
+    for demand_node in demand_nodes["node_id"]:
         node_traces = []
-        for sub_region in sub_regions_under_node:
+        if regional_granularity == "sub_regions":
             trace = get_data.demand_multiple_reference_years(
                 reference_years=reference_year_mapping,
                 directory=trace_data_path,
-                subregion=sub_region,
+                subregion=demand_node,
                 scenario=scenario,
                 year_type=year_type,
                 demand_type="OPSO_MODELLING",
                 poe="POE50",
             )
             node_traces.append(trace)
+        else:
+            sub_regions_to_nem_regions = pd.read_csv(
+                ispypsa_inputs_path / Path("mapping_sub_regions_to_nem_regions.csv")
+            )
+            if regional_granularity == "nem_regions":
+                sub_regions_in_demand_node = sub_regions_to_nem_regions.loc[
+                    sub_regions_to_nem_regions["nem_region_id"] == demand_node,
+                    "isp_sub_region_id",
+                ]
+            elif regional_granularity == "single_region":
+                sub_regions_in_demand_node = sub_regions_to_nem_regions.loc[
+                    :, "isp_sub_region_id"
+                ]
+            for sub_region in sub_regions_in_demand_node:
+                trace = get_data.demand_multiple_reference_years(
+                    reference_years=reference_year_mapping,
+                    directory=trace_data_path,
+                    subregion=sub_region,
+                    scenario=scenario,
+                    year_type=year_type,
+                    demand_type="OPSO_MODELLING",
+                    poe="POE50",
+                )
+                node_traces.append(trace)
         node_traces = pd.concat(node_traces)
         node_trace = node_traces.groupby("Datetime", as_index=False)["Value"].sum()
-        node_trace.to_parquet(Path(output_trace_path, f"{node}.parquet"), index=False)
+        node_trace.to_parquet(
+            Path(output_trace_path, f"{demand_node}.parquet"), index=False
+        )

--- a/src/ispypsa/translator/generators.py
+++ b/src/ispypsa/translator/generators.py
@@ -8,14 +8,15 @@ from ispypsa.translator.mappings import _GENERATOR_ATTRIBUTES
 
 
 def _translate_ecaa_generators(
-    ispypsa_inputs_path: Path | str, granularity: str = "sub_regional"
+    ispypsa_inputs_path: Path | str, regional_granularity: str = "sub_regions"
 ) -> pd.DataFrame:
     """Process data on existing, committed, anticipated, and additional (ECAA) generators
     into a format aligned with PyPSA inputs.
 
     Args:
         ispypsa_inputs_path: Path to directory containing modelling input template CSVs.
-        granularity: Geographical granularity obtained from the model configuration
+        regional_granularity: Regional granularity of the nodes obtained from the model
+            configuration. Defaults to "sub_regions".
 
     Returns:
         `pd.DataFrame`: PyPSA style generator attributes in tabular format.
@@ -24,9 +25,9 @@ def _translate_ecaa_generators(
         ispypsa_inputs_path / Path("ecaa_generators.csv")
     )
 
-    if granularity == "sub_regional":
+    if regional_granularity == "sub_regions":
         _GENERATOR_ATTRIBUTES["sub_region_id"] = "bus"
-    elif granularity == "regional":
+    elif regional_granularity == "nem_regions":
         _GENERATOR_ATTRIBUTES["region_id"] = "bus"
 
     ecaa_generators_pypsa_format = ecaa_generators_template.loc[
@@ -36,7 +37,7 @@ def _translate_ecaa_generators(
         columns=_GENERATOR_ATTRIBUTES
     )
 
-    if granularity == "single_region":
+    if regional_granularity == "single_region":
         ecaa_generators_pypsa_format["bus"] = "NEM"
 
     marginal_costs = {

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -7,13 +7,21 @@ from ispypsa.config.validators import ModelConfig
 @pytest.mark.parametrize(
     "scenario", ["Step Change", "Progressive Change", "Green Energy Exports"]
 )
-@pytest.mark.parametrize("granularity", ["sub_regional", "regional", "single_region"])
+@pytest.mark.parametrize(
+    "regional_granularity", ["sub_regions", "nem_regions", "single_region"]
+)
+@pytest.mark.parametrize("nodes_rezs", ["discrete_nodes", "attached_to_parent_node"])
 @pytest.mark.parametrize("year_type", ["fy", "calendar"])
-def test_valid_config(scenario, granularity, year_type):
+def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
     ModelConfig(
         **{
             "scenario": scenario,
-            "network": {"granularity": granularity},
+            "network": {
+                "nodes": {
+                    "regional_granularity": regional_granularity,
+                    "rezs": nodes_rezs,
+                }
+            },
             "traces": {
                 "year_type": year_type,
                 "start_year": 2025,
@@ -29,7 +37,12 @@ def test_invalid_scenario():
         ModelConfig(
             **{
                 "scenario": "BAU",
-                "network": {"granularity": "sub_regional"},
+                "network": {
+                    "nodes": {
+                        "regional_granularity": "sub_regions",
+                        "rezs": "discrete_nodes",
+                    }
+                },
                 "traces": {
                     "year_type": "fy",
                     "start_year": 2025,
@@ -40,12 +53,38 @@ def test_invalid_scenario():
         )
 
 
-def test_invalid_granularity():
+def test_invalid_node_granularity():
     with pytest.raises(ValidationError):
         ModelConfig(
             **{
                 "scenario": "Step Change",
-                "network": {"granularity": "wastelands"},
+                "network": {
+                    "nodes": {
+                        "regional_granularity": "wastelands",
+                        "rezs": "discrete_nodes",
+                    }
+                },
+                "traces": {
+                    "year_type": "fy",
+                    "start_year": 2025,
+                    "end_year": 2026,
+                    "reference_year_cycle": [2018],
+                },
+            }
+        )
+
+
+def test_invalid_nodes_rezs():
+    with pytest.raises(ValidationError):
+        ModelConfig(
+            **{
+                "scenario": "Step Change",
+                "network": {
+                    "nodes": {
+                        "regional_granularity": "sub_regions",
+                        "rezs": "attached_to_regions",
+                    }
+                },
                 "traces": {
                     "year_type": "fy",
                     "start_year": 2025,
@@ -61,7 +100,12 @@ def test_invalid_end_year():
         ModelConfig(
             **{
                 "scenario": "Step Change",
-                "network": {"granularity": "sub_regional"},
+                "network": {
+                    "nodes": {
+                        "regional_granularity": "sub_regions",
+                        "rezs": "discrete_nodes",
+                    }
+                },
                 "traces": {
                     "year_type": "fy",
                     "start_year": 2025,

--- a/tests/templater/test_flow_paths.py
+++ b/tests/templater/test_flow_paths.py
@@ -6,7 +6,7 @@ from ispypsa.templater.flow_paths import template_flow_paths
 
 def test_flow_paths_templater_regional(workbook_table_cache_test_path: Path):
     flow_paths_template = template_flow_paths(
-        workbook_table_cache_test_path, "regional"
+        workbook_table_cache_test_path, "nem_regions"
     )
     assert flow_paths_template.index.name == "flow_path_name"
     assert all(
@@ -38,7 +38,7 @@ def test_flow_paths_templater_regional(workbook_table_cache_test_path: Path):
 
 def test_flow_paths_templater_sub_regional(workbook_table_cache_test_path: Path):
     flow_paths_template = template_flow_paths(
-        workbook_table_cache_test_path, "sub_regional"
+        workbook_table_cache_test_path, "sub_regions"
     )
     assert flow_paths_template.index.name == "flow_path_name"
     assert all(

--- a/tests/templater/test_nodes.py
+++ b/tests/templater/test_nodes.py
@@ -3,35 +3,61 @@ from pathlib import Path
 
 import pandas as pd
 
-from ispypsa.templater.nodes import template_nodes
+from ispypsa.templater.nodes import (
+    template_nodes,
+    template_region_to_single_sub_region_mapping,
+    template_sub_regions_to_nem_regions_mapping,
+)
 
 
-def test_node_templater_regional(workbook_table_cache_test_path: Path):
-    node_template = template_nodes(workbook_table_cache_test_path, "regional")
+def test_node_templater_nem_regions(workbook_table_cache_test_path: Path):
+    node_template = template_nodes(
+        workbook_table_cache_test_path,
+        regional_granularity="nem_regions",
+        rez_nodes="attached_to_parent_node",
+    )
     assert node_template.index.name == "node_id"
     assert set(node_template.regional_reference_node_voltage_kv) == set((132,))
     assert set(node_template.index) == set(("QLD", "VIC"))
-    assert set(node_template.isp_sub_region) == set(("Southern Queensland", "Victoria"))
+    assert set(node_template.type) == set(("nem_region",))
     assert not node_template.substation_longitude.empty
     assert not node_template.substation_latitude.empty
 
 
-def test_node_templater_sub_regional(workbook_table_cache_test_path: Path):
-    node_template = template_nodes(workbook_table_cache_test_path, "sub_regional")
+def test_node_templater_sub_regions(workbook_table_cache_test_path: Path):
+    node_template = template_nodes(
+        workbook_table_cache_test_path,
+        regional_granularity="sub_regions",
+        rez_nodes="attached_to_parent_node",
+    )
     assert node_template.index.name == "node_id"
     assert set(node_template.sub_region_reference_node_voltage_kv) == set((132,))
     assert set(node_template.index) == set(("SQ", "VIC"))
-    assert set(node_template.nem_region_id) == set(("QLD", "VIC"))
+    assert set(node_template.type) == set(("sub_region",))
     assert not node_template.substation_longitude.empty
     assert not node_template.substation_latitude.empty
 
 
+def test_node_templater_sub_regions_with_rezs(workbook_table_cache_test_path: Path):
+    node_template = template_nodes(
+        workbook_table_cache_test_path,
+        regional_granularity="sub_regions",
+        rez_nodes="discrete_nodes",
+    )
+    assert node_template.index.name == "node_id"
+    assert set(node_template.index) == set(("SQ", "VIC", "Q1", "Q2"))
+    assert set(node_template.type) == set(("sub_region", "rez"))
+
+
 def test_node_templater_single_region(workbook_table_cache_test_path: Path):
-    node_template = template_nodes(workbook_table_cache_test_path, "single_region")
+    node_template = template_nodes(
+        workbook_table_cache_test_path,
+        regional_granularity="single_region",
+        rez_nodes="attached_to_parent_node",
+    )
     assert node_template.index.name == "node_id"
     assert set(node_template.regional_reference_node_voltage_kv) == set((66,))
     assert set(node_template.index) == set(("NEM",))
-    assert set(node_template.nem_region) == set(("Victoria",))
     assert not node_template.substation_longitude.empty
     assert not node_template.substation_latitude.empty
 
@@ -42,13 +68,16 @@ def test_no_substation_coordinates(workbook_table_cache_test_path: Path, mocker)
         "ispypsa.templater.nodes._request_transmission_substation_coordinates",
         return_value=pd.DataFrame(({})).T,
     )
-    node_template = template_nodes(workbook_table_cache_test_path, "sub_regional")
+    node_template = template_nodes(
+        workbook_table_cache_test_path,
+        regional_granularity="sub_regions",
+        rez_nodes="attached_to_parent_node",
+    )
     assert node_template.index.name == "node_id"
     assert set(node_template.sub_region_reference_node_voltage_kv) == set((132,))
     assert set(node_template.index) == set(("SQ", "VIC"))
-    assert set(node_template.nem_region_id) == set(("QLD", "VIC"))
     assert len(node_template) == 2
-    assert len(node_template.columns) == 6
+    assert len(node_template.columns) == 4
 
 
 def test_substation_coordinate_http_error(
@@ -58,13 +87,27 @@ def test_substation_coordinate_http_error(
     requests_mock.get(url, status_code=404)
     # Run the test and expect an HTTPError
     with caplog.at_level(logging.WARNING):
-        template_nodes(workbook_table_cache_test_path)
+        template_nodes(
+            workbook_table_cache_test_path,
+            rez_nodes="attached_to_parent_node",
+        )
     assert "Failed to fetch substation coordinates" in caplog.text
     assert "Network node data will be templated without coordinate data" in caplog.text
 
 
-def test_regional_sub_regional_mapping(workbook_table_cache_test_path: Path):
-    node_template = template_nodes(workbook_table_cache_test_path, "sub_regional")
-    assert node_template.index.name == "node_id"
-    assert set(node_template.index) == set(("SQ", "VIC"))
-    assert set(node_template.nem_region_id) == set(("QLD", "VIC"))
+def test_sub_regions_to_nem_regions_mapping(workbook_table_cache_test_path: Path):
+    mapping = template_sub_regions_to_nem_regions_mapping(
+        workbook_table_cache_test_path
+    )
+    assert set(mapping.index) == set(("SQ", "VIC"))
+    assert mapping.at["SQ", "nem_region_id"] == "QLD"
+    assert mapping.at["VIC", "nem_region_id"] == "VIC"
+
+
+def test_region_to_single_sub_region_mapping(workbook_table_cache_test_path: Path):
+    mapping = template_region_to_single_sub_region_mapping(
+        workbook_table_cache_test_path
+    )
+    assert set(mapping.index) == set(("QLD", "VIC"))
+    assert mapping.at["QLD", "isp_sub_region_id"] == "SQ"
+    assert mapping.at["VIC", "isp_sub_region_id"] == "VIC"

--- a/tests/templater/test_nodes.py
+++ b/tests/templater/test_nodes.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from ispypsa.templater.nodes import (
     template_nodes,
-    template_region_to_single_sub_region_mapping,
+    template_nem_region_to_single_sub_region_mapping,
     template_sub_regions_to_nem_regions_mapping,
 )
 
@@ -105,7 +105,7 @@ def test_sub_regions_to_nem_regions_mapping(workbook_table_cache_test_path: Path
 
 
 def test_region_to_single_sub_region_mapping(workbook_table_cache_test_path: Path):
-    mapping = template_region_to_single_sub_region_mapping(
+    mapping = template_nem_region_to_single_sub_region_mapping(
         workbook_table_cache_test_path
     )
     assert set(mapping.index) == set(("QLD", "VIC"))

--- a/tests/templater/test_renewable_energy_zones.py
+++ b/tests/templater/test_renewable_energy_zones.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 
 from ispypsa.templater.renewable_energy_zones import (
-    template_renewable_energy_zone_locations,
+    template_renewable_energy_zones,
 )
 
 
 def test_renewable_energy_zones_locations(workbook_table_cache_test_path: Path):
-    node_template = template_renewable_energy_zone_locations(
-        workbook_table_cache_test_path
-    )
+    node_template = template_renewable_energy_zones(workbook_table_cache_test_path)
     assert node_template.index.name == "rez_id"
     assert set(node_template.index) == set(("Q1", "Q2"))
     assert set(node_template.isp_sub_region_id) == set(("NQ", "NQ"))


### PR DESCRIPTION
## Config
- Restructured: `network` -> `nodes` -> `regional_granularity` 

## Node template
-  now has a type column, and all mappings removed
- option to include rezs as nodes
  
## Mappings
  - `regional_sub_regional` renamed and always saved
  -  new mapping that maps each NEM region to a single sub region always saved
  - released as `mappings_*.csv`

## Dodo
  - workflow folders renamed

## Bus demand timeseries translator
  - Changes to accommodate config changes, but also refactored based on new mappings and to also handle single region