### PR TITLE
Add model module that creates a and runs a production cost model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ scratch.py
 ## CSVs in model_inputs
 model_data/**/*.csv
 model_data/**/*.parquet
+model_data/**/*.hdf5
 
 # ignore doit database
 .doit*

--- a/dodo.py
+++ b/dodo.py
@@ -185,7 +185,7 @@ def create_and_run_pypsa_model(
     add_buses_to_network(network, pypsa_inputs_location)
     add_lines_to_network(network, pypsa_inputs_location)
     add_ecaa_generators_to_network(network, pypsa_inputs_location)
-    run(network)
+    run(network, solver_name=config.solver)
     save_results(network, pypsa_outputs_location)
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -179,7 +179,7 @@ def create_and_run_pypsa_model(
         config.traces.start_year,
         config.traces.end_year,
         config.traces.year_type,
-        config.temporal_resolution,
+        config.operational_temporal_resolution_min,
     )
     add_carriers_to_network(network, pypsa_inputs_location)
     add_buses_to_network(network, pypsa_inputs_location)

--- a/dodo.py
+++ b/dodo.py
@@ -273,8 +273,8 @@ def task_create_and_run_pypsa_model():
             Path(_PYPSA_FRIENDLY_DIRECTORY, "generators.csv"),
         ],
         "targets": [
-            Path(_PYPSA_OUTPUTS_DIRECTORY, "generator_dispatch.csv"),
-            Path(_PYPSA_OUTPUTS_DIRECTORY, "line_flows_p0.csv"),
-            Path(_PYPSA_OUTPUTS_DIRECTORY, "line_flows_p1.csv"),
+            Path(_PYPSA_OUTPUTS_DIRECTORY, "generator_dispatch.parquet"),
+            Path(_PYPSA_OUTPUTS_DIRECTORY, "line_flows_p0.parquet"),
+            Path(_PYPSA_OUTPUTS_DIRECTORY, "line_flows_p1.parquet"),
         ],
     }

--- a/dodo.py
+++ b/dodo.py
@@ -123,33 +123,25 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
     pypsa_inputs_location: Path,
 ) -> None:
     config = load_config(config_location)
-
     if not pypsa_inputs_location.exists():
         pypsa_inputs_location.mkdir(parents=True)
-
     pypsa_inputs = {}
-
     pypsa_inputs["generators"] = _translate_ecaa_generators(
         ispypsa_inputs_location, config.network.nodes.regional_granularity
     )
-
     pypsa_inputs["buses"] = _translate_nodes_to_buses(
         ispypsa_inputs_location,
     )
-
     pypsa_inputs["lines"] = translate_flow_paths_to_lines(
         ispypsa_inputs_location,
     )
-
     for name, table in pypsa_inputs.items():
         table.to_csv(Path(pypsa_inputs_location, f"{name}.csv"))
-
     reference_year_mapping = construct_reference_year_mapping(
         start_year=config.traces.start_year,
         end_year=config.traces.end_year,
         reference_years=config.traces.reference_year_cycle,
     )
-
     _translate_generator_timeseries(
         ispypsa_inputs_location,
         trace_data_path,
@@ -158,7 +150,6 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
         reference_year_mapping=reference_year_mapping,
         year_type=config.traces.year_type,
     )
-
     _translate_generator_timeseries(
         ispypsa_inputs_location,
         trace_data_path,
@@ -167,7 +158,6 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
         reference_year_mapping=reference_year_mapping,
         year_type=config.traces.year_type,
     )
-
     _translate_buses_demand_timeseries(
         ispypsa_inputs_location,
         trace_data_path,

--- a/dodo.py
+++ b/dodo.py
@@ -272,9 +272,5 @@ def task_create_and_run_pypsa_model():
             Path(_PYPSA_FRIENDLY_DIRECTORY, "lines.csv"),
             Path(_PYPSA_FRIENDLY_DIRECTORY, "generators.csv"),
         ],
-        "targets": [
-            Path(_PYPSA_OUTPUTS_DIRECTORY, "generator_dispatch.parquet"),
-            Path(_PYPSA_OUTPUTS_DIRECTORY, "line_flows_p0.parquet"),
-            Path(_PYPSA_OUTPUTS_DIRECTORY, "line_flows_p1.parquet"),
-        ],
+        "targets": [Path(_PYPSA_OUTPUTS_DIRECTORY, "network.hdf5")],
     }

--- a/dodo.py
+++ b/dodo.py
@@ -42,7 +42,7 @@ from ispypsa.model import (
 _PARSED_WORKBOOK_CACHE = Path("model_data", "workbook_table_cache")
 _ISPYPSA_INPUT_TABLES_DIRECTORY = Path("model_data", "ispypsa_inputs", "tables")
 _PYPSA_FRIENDLY_DIRECTORY = Path("model_data", "pypsa_friendly")
-_PARSED_TRACE_DIRECTORY = Path("/home/abi/isp-traces/parsed-traces")
+_PARSED_TRACE_DIRECTORY = Path("D:/isp_2024_data/parsed_trace_data")
 _CONFIG_PATH = Path("model_data", "ispypsa_inputs", "ispypsa_config.yaml")
 _PYPSA_OUTPUTS_DIRECTORY = Path("model_data", "outputs")
 

--- a/dodo.py
+++ b/dodo.py
@@ -183,6 +183,8 @@ def create_and_run_pypsa_model(
     config_location: Path, pypsa_inputs_location: Path, pypsa_outputs_location: Path
 ) -> None:
     config = load_config(config_location)
+    if not pypsa_outputs_location.exists():
+        pypsa_outputs_location.mkdir(parents=True)
     network = initialise_network(
         config.traces.start_year,
         config.traces.end_year,

--- a/model_data/ispypsa_inputs/ispypsa_config.yaml
+++ b/model_data/ispypsa_inputs/ispypsa_config.yaml
@@ -26,3 +26,20 @@ traces:
   start_year: 2025
   end_year: 2025
   reference_year_cycle: [2018]
+# External solver to use
+# Options (refer to https://pypsa.readthedocs.io/en/latest/getting-started/installation.html):
+#   Free, and by default, installed with ISPyPSA:
+#     "highs"
+#   Free, but must be installed by the user:
+#     "cbc"
+#     "glpk"
+#     "scip"
+#   Not free and must be installed by the user:
+#     "cplex"
+#     "gurobi"
+#     "xpress"
+#     "mosek"
+#     "copt"
+#     "mindopt"
+#     "pips"
+solver: highs

--- a/model_data/ispypsa_inputs/ispypsa_config.yaml
+++ b/model_data/ispypsa_inputs/ispypsa_config.yaml
@@ -6,6 +6,7 @@
 #   "Step Change": Fulfils Australia’s emission reduction commitments in a growing economy
 #   "Green Energy Exports": Sees very strong industrial decarbonisation and low-emission energy exports
 scenario: Step Change
+temporal_resolution: 30min
 network:
   nodes:
     # The regional granularity of the nodes in the modelled network
@@ -23,5 +24,5 @@ network:
 traces:
   year_type: fy
   start_year: 2025
-  end_year: 2026
+  end_year: 2025
   reference_year_cycle: [2018]

--- a/model_data/ispypsa_inputs/ispypsa_config.yaml
+++ b/model_data/ispypsa_inputs/ispypsa_config.yaml
@@ -6,7 +6,7 @@
 #   "Step Change": Fulfils Australia’s emission reduction commitments in a growing economy
 #   "Green Energy Exports": Sees very strong industrial decarbonisation and low-emission energy exports
 scenario: Step Change
-temporal_resolution: 30min
+operational_temporal_resolution_min: 30
 network:
   nodes:
     # The regional granularity of the nodes in the modelled network

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "pandas>=2.2.2",
-    "pypsa>=0.30.0",
+    "pypsa>=0.31.1",
     "isp-workbook-parser>=2.0.1",
     "pyyaml>=6.0.2",
     "doit>=0.36.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -53,12 +53,18 @@ cloudpickle==3.0.0
     # via dask
     # via doit
 colorama==0.4.6
+    # via click
+    # via ipython
+    # via pytest
+    # via sphinx
     # via sphinx-autobuild
+    # via tqdm
 comm==0.2.2
     # via ipykernel
 contourpy==1.3.0
     # via matplotlib
 coverage==7.6.1
+    # via coverage
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
@@ -235,8 +241,6 @@ parso==0.8.4
     # via jedi
 partd==1.4.2
     # via dask
-pexpect==4.9.0
-    # via ipython
 pillow==10.4.0
     # via matplotlib
 platformdirs==4.2.2
@@ -252,8 +256,6 @@ prompt-toolkit==3.0.47
     # via ipython
 psutil==6.0.0
     # via ipykernel
-ptyprocess==0.7.0
-    # via pexpect
 pure-eval==0.2.3
     # via stack-data
 py-cpuinfo==9.0.0
@@ -279,7 +281,7 @@ pyparsing==3.1.4
     # via matplotlib
 pyproj==3.6.1
     # via geopandas
-pypsa==0.30.0
+pypsa==0.31.1
     # via ispypsa
 pytest==8.3.2
     # via pytest-cov
@@ -292,6 +294,8 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
+pywin32==308
+    # via jupyter-core
 pyyaml==6.0.2
     # via dask
     # via isp-workbook-parser
@@ -318,8 +322,6 @@ rpds-py==0.20.0
 scipy==1.14.1
     # via linopy
     # via pypsa
-setuptools==74.1.2
-    # via sphinx-togglebutton
 shapely==2.0.6
     # via geopandas
 six==1.16.0
@@ -418,3 +420,5 @@ xmltodict==0.13.0
     # via ispypsa
 zipp==3.20.1
     # via importlib-metadata
+setuptools==74.1.2
+    # via sphinx-togglebutton

--- a/requirements.lock
+++ b/requirements.lock
@@ -27,6 +27,9 @@ click==8.1.7
 cloudpickle==3.0.0
     # via dask
     # via doit
+colorama==0.4.6
+    # via click
+    # via tqdm
 contourpy==1.3.0
     # via matplotlib
 cycler==0.12.1
@@ -134,7 +137,7 @@ pyparsing==3.1.4
     # via matplotlib
 pyproj==3.6.1
     # via geopandas
-pypsa==0.30.0
+pypsa==0.31.1
     # via ispypsa
 python-dateutil==2.9.0.post0
     # via matplotlib

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -35,3 +35,16 @@ class ModelConfig(BaseModel):
     temporal_resolution: Literal["30min"]
     network: NetworkConfig
     traces: TraceConfig
+    solver: Literal[
+        "highs",
+        "cbc",
+        "glpk",
+        "scip",
+        "cplex",
+        "gurobi",
+        "xpress",
+        "mosek",
+        "copt",
+        "mindopt",
+        "pips",
+    ]

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -32,5 +32,6 @@ class TraceConfig(BaseModel):
 
 class ModelConfig(BaseModel):
     scenario: Literal[tuple(_ISP_SCENARIOS)]
+    temporal_resolution: Literal["30min"]
     network: NetworkConfig
     traces: TraceConfig

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -32,7 +32,7 @@ class TraceConfig(BaseModel):
 
 class ModelConfig(BaseModel):
     scenario: Literal[tuple(_ISP_SCENARIOS)]
-    temporal_resolution: Literal["30min"]
+    operational_temporal_resolution_min: int
     network: NetworkConfig
     traces: TraceConfig
     solver: Literal[
@@ -48,3 +48,21 @@ class ModelConfig(BaseModel):
         "mindopt",
         "pips",
     ]
+
+    @field_validator("operational_temporal_resolution_min")
+    @classmethod
+    def validate_temporal_resolution_min(cls, operational_temporal_resolution_min: int):
+        # TODO properly implement temporal aggregation so this first check can be removed.
+        if operational_temporal_resolution_min != 30:
+            raise ValueError(
+                "config operational_temporal_resolution_min must equal 30 min"
+            )
+        if operational_temporal_resolution_min < 30:
+            raise ValueError(
+                "config operational_temporal_resolution_min must be greater than or equal to 30 min"
+            )
+        if (operational_temporal_resolution_min % 30) != 0:
+            raise ValueError(
+                "config operational_temporal_resolution_min must be multiple of 30 min"
+            )
+        return operational_temporal_resolution_min

--- a/src/ispypsa/model/__init__.py
+++ b/src/ispypsa/model/__init__.py
@@ -1,0 +1,18 @@
+from ispypsa.model.buses import add_buses_to_network
+from ispypsa.model.initialise import initialise_network
+from ispypsa.model.generators import add_ecaa_generators_to_network
+from ispypsa.model.carriers import add_carriers_to_network
+from ispypsa.model.lines import add_lines_to_network
+from ispypsa.model.run import run
+from ispypsa.model.save_results import save_results
+
+
+__all__ = [
+    "add_buses_to_network",
+    "initialise_network",
+    "add_ecaa_generators_to_network",
+    "add_carriers_to_network",
+    "add_lines_to_network",
+    "run",
+    "save_results",
+]

--- a/src/ispypsa/model/buses.py
+++ b/src/ispypsa/model/buses.py
@@ -6,14 +6,16 @@ import pypsa
 
 def _add_bus_to_network(
     bus_name: str, network: pypsa.Network, path_to_demand_traces: Path
-):
+) -> None:
     """
-    Adds a Bus to the network and if a demand trace for the Bus exists also adds that as a Load attached to the Bus.
+    Adds a Bus to the network and if a demand trace for the Bus exists, also adds the
+    trace to a Load attached to the Bus.
 
     Args:
-        bus_name: str defining the buses name
-        network: The pypsa.Network object to add the buses to
-        path_to_demand_traces: pathlib.Path for the directory containing demand traces
+        bus_name: String defining the bus name
+        network: The `pypsa.Network` object
+        path_to_demand_traces: `pathlib.Path` that points to the
+            directory containing demand traces
 
     Returns: None
     """
@@ -22,6 +24,7 @@ def _add_bus_to_network(
     demand_trace_path = path_to_demand_traces / Path(f"{bus_name}.parquet")
     if demand_trace_path.exists():
         demand = pd.read_parquet(demand_trace_path)
+        # datetime in nanoseconds required by PyPSA
         demand["Datetime"] = demand["Datetime"].astype("datetime64[ns]")
         demand = demand.set_index("Datetime")
         network.add(
@@ -32,12 +35,14 @@ def _add_bus_to_network(
         )
 
 
-def add_buses_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
-    """Adds buses from buses.csv in the path_pypsa_inputs directory to the pypsa.Network.
+def add_buses_to_network(network: pypsa.Network, path_pypsa_inputs: Path) -> None:
+    """Adds Buses from `buses.csv` in the `path_to_pypsa_inputs` directory to
+    the `pypsa.Network`.
 
     Args:
-         network: The pypsa.Network object
-         path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+        network: The `pypsa.Network` object
+        path_pypsa_inputs: `pathlib.Path` that points to the directory containing
+            PyPSA inputs
 
     Returns: None
     """

--- a/src/ispypsa/model/buses.py
+++ b/src/ispypsa/model/buses.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import pandas as pd
+import pypsa
+
+
+def _add_bus_to_network(
+    bus_name: str, network: pypsa.Network, path_to_demand_traces: Path
+):
+    """
+    Adds a Bus to the network and if a demand trace for the Bus exists also adds that as a Load attached to the Bus.
+
+    Args:
+        bus_name: str defining the buses name
+        network: The pypsa.Network object to add the buses to
+        path_to_demand_traces: pathlib.Path for the directory containing demand traces
+
+    Returns: None
+    """
+    network.add(class_name="Bus", name=bus_name)
+
+    demand_trace_path = path_to_demand_traces / Path(f"{bus_name}.parquet")
+    if demand_trace_path.exists():
+        demand = pd.read_parquet(demand_trace_path)
+        demand["Datetime"] = demand["Datetime"].astype("datetime64[ns]")
+        demand = demand.set_index("Datetime")
+        network.add(
+            class_name="Load",
+            name=f"load_{bus_name}",
+            bus=bus_name,
+            p_set=demand["Value"],
+        )
+
+
+def add_buses_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
+    """Adds buses from buses.csv in the path_pypsa_inputs directory to the pypsa.Network.
+
+    Args:
+         network: The pypsa.Network object
+         path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+
+    Returns: None
+    """
+    buses = pd.read_csv(path_pypsa_inputs / Path("buses.csv"))
+    path_to_demand_traces = path_pypsa_inputs / Path("demand_traces")
+    buses["name"].apply(
+        lambda x: _add_bus_to_network(x, network, path_to_demand_traces)
+    )

--- a/src/ispypsa/model/carriers.py
+++ b/src/ispypsa/model/carriers.py
@@ -4,13 +4,14 @@ import pandas as pd
 import pypsa
 
 
-def add_carriers_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
-    """Adds the Carriers in the ecaa_generators.csv table (path_pypsa_inputs directory) and the AC Carrier to the
-    pypsa.Network.
+def add_carriers_to_network(network: pypsa.Network, path_pypsa_inputs: Path) -> None:
+    """Adds the Carriers in the `ecaa_generators.csv table` (located in the
+    `path_pypsa_inputs` directory), and the AC Carrier to the `pypsa.Network`.
 
     Args:
-         network: The pypsa.Network object
-         path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+         network: The `pypsa.Network` object
+         path_pypsa_inputs: `pathlib.Path` that points to the directory containing
+              PyPSA inputs
 
     Returns: None
     """

--- a/src/ispypsa/model/carriers.py
+++ b/src/ispypsa/model/carriers.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+import pandas as pd
+import pypsa
+
+
+def add_carriers_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
+    """Adds the Carriers in the ecaa_generators.csv table (path_pypsa_inputs directory) and the AC Carrier to the
+    pypsa.Network.
+
+    Args:
+         network: The pypsa.Network object
+         path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+
+    Returns: None
+    """
+    ecaa_generators = pd.read_csv(path_pypsa_inputs / Path("generators.csv"))
+    carriers = list(ecaa_generators["carrier"].unique()) + ["AC"]
+    network.add("Carrier", carriers)

--- a/src/ispypsa/model/generators.py
+++ b/src/ispypsa/model/generators.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+import pandas as pd
+import pypsa
+
+
+def _get_trace_data(
+    generator_name: str, path_to_solar_traces: Path, path_to_wind_traces: Path
+):
+    """Fetches trace data for a generator from directories contain solar and wind traces.
+
+    If a trace for the generator cannot be found the None value returned.
+
+    Args:
+        generator_name: str defining the generators name
+        path_to_solar_traces: pathlib.Path for directory containing solar traces
+        path_to_demand_traces: pathlib.Path for directory containing solar traces
+
+    Returns:
+        Dataframe with demand trace data or None value.
+    """
+    filename = Path(f"{generator_name}.parquet")
+    solar_trace_filepath = path_to_solar_traces / filename
+    wind_trace_filepath = path_to_wind_traces / filename
+    if solar_trace_filepath.exists():
+        trace_data = pd.read_parquet(solar_trace_filepath)
+    elif wind_trace_filepath.exists():
+        trace_data = pd.read_parquet(wind_trace_filepath)
+    else:
+        trace_data = None
+    return trace_data
+
+
+def _add_ecaa_generator_to_network(
+    generator_definition: dict,
+    network: pypsa.Network,
+    path_to_solar_traces: Path,
+    path_to_wind_traces: Path,
+):
+    """Adds a generator to a pypsa.Network based on dict that matches pypsa Generator attributes.
+
+    If trace data for the generator is available in then a dynamic availability for the generator (p_max_pu) is set,
+    otherwise only the nominal capacity of the generator is used.
+
+    """
+    generator_definition["class_name"] = "Generator"
+
+    trace_data = _get_trace_data(
+        generator_definition["name"], path_to_solar_traces, path_to_wind_traces
+    )
+
+    if trace_data is not None:
+        trace_data["Datetime"] = trace_data["Datetime"].astype("datetime64[ns]")
+        generator_definition["p_max_pu"] = trace_data.set_index("Datetime")["Value"]
+
+    network.add(**generator_definition)
+
+
+def add_ecaa_generators_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
+    """Adds the generators in ecaa_generators.csv table (path_pypsa_inputs directory) to the pypsa.Network.
+
+    Args:
+         network: The pypsa.Network object
+         path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+
+    Returns: None
+    """
+    ecaa_generators = pd.read_csv(path_pypsa_inputs / Path("generators.csv"))
+    path_to_solar_traces = path_pypsa_inputs / Path("solar_traces")
+    path_to_wind_traces = path_pypsa_inputs / Path("wind_traces")
+    ecaa_generators.apply(
+        lambda row: _add_ecaa_generator_to_network(
+            row.to_dict(), network, path_to_solar_traces, path_to_wind_traces
+        ),
+        axis=1,
+    )

--- a/src/ispypsa/model/generators.py
+++ b/src/ispypsa/model/generators.py
@@ -9,15 +9,15 @@ def _get_trace_data(
 ):
     """Fetches trace data for a generator from directories contain solar and wind traces.
 
-    If a trace for the generator cannot be found the None value returned.
+    If a trace for the generator cannot be found, the function returns None.
 
     Args:
-        generator_name: str defining the generators name
-        path_to_solar_traces: pathlib.Path for directory containing solar traces
-        path_to_demand_traces: pathlib.Path for directory containing solar traces
+        generator_name: String defining the generator's name
+        path_to_solar_traces: `pathlib.Path` for directory containing solar traces
+        path_to_demand_traces: `pathlib.Path` for directory containing solar traces
 
     Returns:
-        Dataframe with demand trace data or None value.
+        DataFrame with demand trace data or None value.
     """
     filename = Path(f"{generator_name}.parquet")
     solar_trace_filepath = path_to_solar_traces / filename
@@ -36,11 +36,13 @@ def _add_ecaa_generator_to_network(
     network: pypsa.Network,
     path_to_solar_traces: Path,
     path_to_wind_traces: Path,
-):
-    """Adds a generator to a pypsa.Network based on dict that matches pypsa Generator attributes.
+) -> None:
+    """Adds a generator to a pypsa.Network based on a dict containing PyPSA Generator
+    attributes.
 
-    If trace data for the generator is available in then a dynamic availability for the generator (p_max_pu) is set,
-    otherwise only the nominal capacity of the generator is used.
+    If trace data for the generator is available, then a dynamic maximum availability
+    for the generator is applied (via `p_max_pu`). Otherwise, the nominal capacity of the
+    generator is used to apply a static maximum availability.
 
     """
     generator_definition["class_name"] = "Generator"
@@ -56,12 +58,16 @@ def _add_ecaa_generator_to_network(
     network.add(**generator_definition)
 
 
-def add_ecaa_generators_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
-    """Adds the generators in ecaa_generators.csv table (path_pypsa_inputs directory) to the pypsa.Network.
+def add_ecaa_generators_to_network(
+    network: pypsa.Network, path_pypsa_inputs: Path
+) -> None:
+    """Adds the generators in `ecaa_generators.csv` table (located in the
+    `path_pypsa_inputs` directory) to the `pypsa.Network`.
 
     Args:
-         network: The pypsa.Network object
-         path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+        network: The `pypsa.Network` object
+        path_pypsa_inputs: `pathlib.Path` that points to the directory containing
+            PyPSA inputs
 
     Returns: None
     """

--- a/src/ispypsa/model/initialise.py
+++ b/src/ispypsa/model/initialise.py
@@ -5,7 +5,10 @@ import pypsa
 
 
 def prepare_snapshot_index(
-    start_year: int, end_year: int, temporal_resolution: str, year_type: str
+    start_year: int,
+    end_year: int,
+    operational_temporal_resolution_min: str,
+    year_type: str,
 ) -> pd.DatetimeIndex:
     """Creates a DatetimeIndex defining the snapshots for the model.
 
@@ -18,8 +21,7 @@ def prepare_snapshot_index(
         year_type: The year type. 'fy' for financial years, and 'calendar' for calendar
             years. For 'fy', `start_year` and `end_year` refer to the year  in which
             the financial year ends.
-        temporal_resolution: the temporal resolution of the model defined by a
-            number-unit combo accepted by `pd.date_range`, e.g. '30min', '1h', or '3h'.
+        operational_temporal_resolution_min: int defining the temporal resolution in minutes.
     """
     if year_type == "fy":
         start_date = datetime(year=start_year - 1, month=7, day=1, hour=0, minute=30)
@@ -27,13 +29,20 @@ def prepare_snapshot_index(
     else:
         start_date = datetime(year=start_year, month=1, day=1, hour=0, minute=30)
         end_date = datetime(year=end_year + 1, month=1, day=1, hour=0, minute=0)
-    time_index = pd.date_range(start=start_date, end=end_date, freq=temporal_resolution)
+    time_index = pd.date_range(
+        start=start_date,
+        end=end_date,
+        freq=str(operational_temporal_resolution_min) + "min",
+    )
     time_index.strftime("'%Y-%m-%d %H:%M:%S")
     return time_index
 
 
 def initialise_network(
-    start_year: int, end_year: int, year_type: str, temporal_resolution: str
+    start_year: int,
+    end_year: int,
+    year_type: str,
+    operational_temporal_resolution_min: int,
 ) -> pypsa.Network:
     """Creates a `pypsa.Network object` with snapshots defined.
 
@@ -43,14 +52,13 @@ def initialise_network(
         year_type: The year type. 'fy' for financial years, and 'calendar' for calendar
             years. For 'fy', `start_year` and `end_year` refer to the year  in which
             the financial year ends.
-        temporal_resolution: the temporal resolution of the model defined by a
-            number-unit combo accepted by `pd.date_range`, e.g. '30min', '1h', or '3h'.
+        operational_temporal_resolution_min: int defining the temporal resolution in minutes.
 
     Returns:
         `pypsa.Network` object
     """
     time_index = prepare_snapshot_index(
-        start_year, end_year, temporal_resolution, year_type
+        start_year, end_year, operational_temporal_resolution_min, year_type
     )
     network = pypsa.Network(snapshots=time_index)
     return network

--- a/src/ispypsa/model/initialise.py
+++ b/src/ispypsa/model/initialise.py
@@ -4,19 +4,22 @@ import pandas as pd
 import pypsa
 
 
-def prepare_snapshot_index(start_year, end_year, temporal_resolution, year_type):
-    """Creates a pd datetime index defining the snapshots for the model.
+def prepare_snapshot_index(
+    start_year: int, end_year: int, temporal_resolution: str, year_type: str
+) -> pd.DatetimeIndex:
+    """Creates a DatetimeIndex defining the snapshots for the model.
 
-    The index will start at the beginning of the start_year and to the end of the end_year with the given temporal
-    resolution.
+    The index will start at the beginning of `start_year` and finish at the end of
+    `end_year` with the specified temporal resolution.
 
     Args:
-        start_year: int defining the first year the model covers (i.e. inclusive)
-        end_year: int defining the last year the model covers (i.e. inclusive)
-        year_type: str defining the year type, 'fy' for financial years, and 'calendar' for calendar years. For 'fy' the
-        int definition of a financial is the year the financial ends.
-        temporal_resolution: the temporal resolution of the model defined by a number unit combo accepted by
-            pd.date_range i.e. '30min', '1h', or '3h'.
+        start_year: the first year the model covers (i.e. inclusive)
+        end_year: the last year the model covers (i.e. inclusive)
+        year_type: The year type. 'fy' for financial years, and 'calendar' for calendar
+            years. For 'fy', `start_year` and `end_year` refer to the year  in which
+            the financial year ends.
+        temporal_resolution: the temporal resolution of the model defined by a
+            number-unit combo accepted by `pd.date_range`, e.g. '30min', '1h', or '3h'.
     """
     if year_type == "fy":
         start_date = datetime(year=start_year - 1, month=7, day=1, hour=0, minute=30)
@@ -24,27 +27,27 @@ def prepare_snapshot_index(start_year, end_year, temporal_resolution, year_type)
     else:
         start_date = datetime(year=start_year, month=1, day=1, hour=0, minute=30)
         end_date = datetime(year=end_year + 1, month=1, day=1, hour=0, minute=0)
-
     time_index = pd.date_range(start=start_date, end=end_date, freq=temporal_resolution)
-
     time_index.strftime("'%Y-%m-%d %H:%M:%S")
-
     return time_index
 
 
 def initialise_network(
     start_year: int, end_year: int, year_type: str, temporal_resolution: str
-):
-    """Creates a pypsa.Network object with snapshots defined.
+) -> pypsa.Network:
+    """Creates a `pypsa.Network object` with snapshots defined.
 
     Args:
-        start_year: int defining the first year the model covers (i.e. inclusive)
-        end_year: int defining the last year the model covers (i.e. inclusive)
-        year_type: str defining the year type, 'fy' for financial years, and 'calendar' for calendar years. For 'fy' the
-        int definition of a financial is the year the financial ends.
-        temporal_resolution: the temporal resolution of the model defined by a number unit combo accepted by
-            pd.date_range i.e. '30min', '1h', or '3h'.
+        start_year: the first year the model covers (i.e. inclusive)
+        end_year: the last year the model covers (i.e. inclusive)
+        year_type: The year type. 'fy' for financial years, and 'calendar' for calendar
+            years. For 'fy', `start_year` and `end_year` refer to the year  in which
+            the financial year ends.
+        temporal_resolution: the temporal resolution of the model defined by a
+            number-unit combo accepted by `pd.date_range`, e.g. '30min', '1h', or '3h'.
 
+    Returns:
+        `pypsa.Network` object
     """
     time_index = prepare_snapshot_index(
         start_year, end_year, temporal_resolution, year_type

--- a/src/ispypsa/model/initialise.py
+++ b/src/ispypsa/model/initialise.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+import pandas as pd
+import pypsa
+
+
+def prepare_snapshot_index(start_year, end_year, temporal_resolution, year_type):
+    """Creates a pd datetime index defining the snapshots for the model.
+
+    The index will start at the beginning of the start_year and to the end of the end_year with the given temporal
+    resolution.
+
+    Args:
+        start_year: int defining the first year the model covers (i.e. inclusive)
+        end_year: int defining the last year the model covers (i.e. inclusive)
+        year_type: str defining the year type, 'fy' for financial years, and 'calendar' for calendar years. For 'fy' the
+        int definition of a financial is the year the financial ends.
+        temporal_resolution: the temporal resolution of the model defined by a number unit combo accepted by
+            pd.date_range i.e. '30min', '1h', or '3h'.
+    """
+    if year_type == "fy":
+        start_date = datetime(year=start_year - 1, month=7, day=1, hour=0, minute=30)
+        end_date = datetime(year=end_year, month=7, day=1, hour=0, minute=0)
+    else:
+        start_date = datetime(year=start_year, month=1, day=1, hour=0, minute=30)
+        end_date = datetime(year=end_year + 1, month=1, day=1, hour=0, minute=0)
+
+    time_index = pd.date_range(start=start_date, end=end_date, freq=temporal_resolution)
+
+    time_index.strftime("'%Y-%m-%d %H:%M:%S")
+
+    return time_index
+
+
+def initialise_network(
+    start_year: int, end_year: int, year_type: str, temporal_resolution: str
+):
+    """Creates a pypsa.Network object with snapshots defined.
+
+    Args:
+        start_year: int defining the first year the model covers (i.e. inclusive)
+        end_year: int defining the last year the model covers (i.e. inclusive)
+        year_type: str defining the year type, 'fy' for financial years, and 'calendar' for calendar years. For 'fy' the
+        int definition of a financial is the year the financial ends.
+        temporal_resolution: the temporal resolution of the model defined by a number unit combo accepted by
+            pd.date_range i.e. '30min', '1h', or '3h'.
+
+    """
+    time_index = prepare_snapshot_index(
+        start_year, end_year, temporal_resolution, year_type
+    )
+    network = pypsa.Network(snapshots=time_index)
+    return network

--- a/src/ispypsa/model/initialise.py
+++ b/src/ispypsa/model/initialise.py
@@ -7,7 +7,7 @@ import pypsa
 def prepare_snapshot_index(
     start_year: int,
     end_year: int,
-    operational_temporal_resolution_min: str,
+    operational_temporal_resolution_min: int,
     year_type: str,
 ) -> pd.DatetimeIndex:
     """Creates a DatetimeIndex defining the snapshots for the model.

--- a/src/ispypsa/model/lines.py
+++ b/src/ispypsa/model/lines.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pandas as pd
+import pypsa
+
+
+def add_lines_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
+    """Adds the Lines defined in the path_pypsa_inputs directory to the pypsa.Network object.
+
+    Args:
+        network: The pypsa.Network object
+        path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+
+    Returns: None
+    """
+    lines = pd.read_csv(path_pypsa_inputs / Path("lines.csv"))
+    lines["class_name"] = "Line"
+    lines["x"] = 1
+    lines["r"] = 1
+    lines.apply(lambda row: network.add(**row.to_dict()), axis=1)

--- a/src/ispypsa/model/lines.py
+++ b/src/ispypsa/model/lines.py
@@ -4,12 +4,14 @@ import pandas as pd
 import pypsa
 
 
-def add_lines_to_network(network: pypsa.Network, path_pypsa_inputs: Path):
-    """Adds the Lines defined in the path_pypsa_inputs directory to the pypsa.Network object.
+def add_lines_to_network(network: pypsa.Network, path_pypsa_inputs: Path) -> None:
+    """Adds the Lines defined in `lines.csv` in the `path_pypsa_inputs` directory to the
+    `pypsa.Network` object.
 
     Args:
-        network: The pypsa.Network object
-        path_pypsa_inputs: pathlib.Path for directory containing pypsa inputs
+        network: The `pypsa.Network` object
+        path_pypsa_inputs: `pathlib.Path` that points to the directory containing
+            PyPSA inputs
 
     Returns: None
     """

--- a/src/ispypsa/model/run.py
+++ b/src/ispypsa/model/run.py
@@ -1,12 +1,10 @@
 import pypsa
 
 
-def run(network: pypsa.Network):
-    """Runs optimise for the pypsa.Network
+def run(network: pypsa.Network) -> None:
+    """Runs the model by calling `optimize()` on the `pypsa.Network`
 
     Args:
-        network: The pypsa.Network object
-
-
+        network: The `pypsa.Network` object
     """
     network.optimize()

--- a/src/ispypsa/model/run.py
+++ b/src/ispypsa/model/run.py
@@ -1,10 +1,13 @@
 import pypsa
 
 
-def run(network: pypsa.Network) -> None:
+def run(network: pypsa.Network, solver_name="highs", solver_options={}) -> None:
     """Runs the model by calling `optimize()` on the `pypsa.Network`
 
     Args:
         network: The `pypsa.Network` object
+        solver_name: PyPSA/linopy-compatible solver. See
+            https://pypsa.readthedocs.io/en/latest/getting-started/installation.html
+        solver_options: Options to pass to the solver.
     """
-    network.optimize()
+    network.optimize(solver_name=solver_name, solver_options=solver_options)

--- a/src/ispypsa/model/run.py
+++ b/src/ispypsa/model/run.py
@@ -1,0 +1,12 @@
+import pypsa
+
+
+def run(network: pypsa.Network):
+    """Runs optimise for the pypsa.Network
+
+    Args:
+        network: The pypsa.Network object
+
+
+    """
+    network.optimize()

--- a/src/ispypsa/model/save_results.py
+++ b/src/ispypsa/model/save_results.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import pypsa
+
+
+def save_results(network: pypsa.Network, pypsa_outputs_location: Path):
+    network.generators_t.p.to_parquet(
+        Path(pypsa_outputs_location, "generator_dispatch.parquet")
+    )
+    network.lines_t.p0.to_parquet(Path(pypsa_outputs_location, "line_flows_p0.parquet"))
+    network.lines_t.p0.to_parquet(Path(pypsa_outputs_location, "line_flows_p1.parquet"))

--- a/src/ispypsa/model/save_results.py
+++ b/src/ispypsa/model/save_results.py
@@ -3,8 +3,4 @@ import pypsa
 
 
 def save_results(network: pypsa.Network, pypsa_outputs_location: Path) -> None:
-    network.generators_t.p.to_parquet(
-        Path(pypsa_outputs_location, "generator_dispatch.parquet")
-    )
-    network.lines_t.p0.to_parquet(Path(pypsa_outputs_location, "line_flows_p0.parquet"))
-    network.lines_t.p0.to_parquet(Path(pypsa_outputs_location, "line_flows_p1.parquet"))
+    network.export_to_hdf5(Path(pypsa_outputs_location, "network.hdf5"))

--- a/src/ispypsa/model/save_results.py
+++ b/src/ispypsa/model/save_results.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pypsa
 
 
-def save_results(network: pypsa.Network, pypsa_outputs_location: Path):
+def save_results(network: pypsa.Network, pypsa_outputs_location: Path) -> None:
     network.generators_t.p.to_parquet(
         Path(pypsa_outputs_location, "generator_dispatch.parquet")
     )

--- a/src/ispypsa/translator/lines.py
+++ b/src/ispypsa/translator/lines.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pandas as pd
+
+from ispypsa.translator.mappings import _LINE_ATTRIBUTES
+
+
+def translate_flow_paths_to_lines(ispypsa_inputs_path: Path | str) -> pd.DataFrame:
+    """Process network line data into a format aligned with PyPSA inputs.
+
+    Args:
+        ispypsa_inputs_path: Path to directory containing modelling input template CSVs.
+
+    Returns:
+        `pd.DataFrame`: PyPSA style generator attributes in tabular format.
+    """
+    lines = pd.read_csv(ispypsa_inputs_path / Path("flow_paths.csv"))
+    lines = lines.loc[:, _LINE_ATTRIBUTES.keys()]
+    lines = lines.rename(columns=_LINE_ATTRIBUTES)
+    lines = lines.set_index("name", drop=True)
+    return lines

--- a/src/ispypsa/translator/mappings.py
+++ b/src/ispypsa/translator/mappings.py
@@ -5,3 +5,11 @@ _GENERATOR_ATTRIBUTES = {
 }
 
 _BUS_ATTRIBUTES = {"node_id": "name"}
+
+_LINE_ATTRIBUTES = {
+    "flow_path_name": "name",
+    "node_from": "bus0",
+    "node_to": "bus1",
+    "forward_direction_mw_summer_typical": "s_nom",
+    # "reverse_direction_mw_summer_typical": ""
+}

--- a/src/ispypsa/translator/mappings.py
+++ b/src/ispypsa/translator/mappings.py
@@ -11,5 +11,6 @@ _LINE_ATTRIBUTES = {
     "node_from": "bus0",
     "node_to": "bus1",
     "forward_direction_mw_summer_typical": "s_nom",
+    # TODO: implement reverse direction limit
     # "reverse_direction_mw_summer_typical": ""
 }

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -16,7 +16,7 @@ def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
     ModelConfig(
         **{
             "scenario": scenario,
-            "temporal_resolution": "30min",
+            "operational_temporal_resolution_min": 30,
             "network": {
                 "nodes": {
                     "regional_granularity": regional_granularity,
@@ -39,7 +39,7 @@ def test_invalid_scenario():
         ModelConfig(
             **{
                 "scenario": "BAU",
-                "temporal_resolution": "30min",
+                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
@@ -62,7 +62,7 @@ def test_invalid_node_granularity():
         ModelConfig(
             **{
                 "scenario": "Step Change",
-                "temporal_resolution": "30min",
+                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "wastelands",
@@ -85,7 +85,7 @@ def test_invalid_nodes_rezs():
         ModelConfig(
             **{
                 "scenario": "Step Change",
-                "temporal_resolution": "30min",
+                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
@@ -108,7 +108,7 @@ def test_invalid_end_year():
         ModelConfig(
             **{
                 "scenario": "Step Change",
-                "temporal_resolution": "30min",
+                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -16,6 +16,7 @@ def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
     ModelConfig(
         **{
             "scenario": scenario,
+            "temporal_resolution": "30min",
             "network": {
                 "nodes": {
                     "regional_granularity": regional_granularity,
@@ -37,6 +38,7 @@ def test_invalid_scenario():
         ModelConfig(
             **{
                 "scenario": "BAU",
+                "temporal_resolution": "30min",
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
@@ -58,6 +60,7 @@ def test_invalid_node_granularity():
         ModelConfig(
             **{
                 "scenario": "Step Change",
+                "temporal_resolution": "30min",
                 "network": {
                     "nodes": {
                         "regional_granularity": "wastelands",
@@ -79,6 +82,7 @@ def test_invalid_nodes_rezs():
         ModelConfig(
             **{
                 "scenario": "Step Change",
+                "temporal_resolution": "30min",
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
@@ -100,6 +104,7 @@ def test_invalid_end_year():
         ModelConfig(
             **{
                 "scenario": "Step Change",
+                "temporal_resolution": "30min",
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -29,6 +29,7 @@ def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
                 "end_year": 2026,
                 "reference_year_cycle": [2018],
             },
+            "solver": "highs",
         }
     )
 
@@ -51,6 +52,7 @@ def test_invalid_scenario():
                     "end_year": 2026,
                     "reference_year_cycle": [2018],
                 },
+                "solver": "highs",
             }
         )
 
@@ -73,6 +75,7 @@ def test_invalid_node_granularity():
                     "end_year": 2026,
                     "reference_year_cycle": [2018],
                 },
+                "solver": "highs",
             }
         )
 
@@ -95,6 +98,7 @@ def test_invalid_nodes_rezs():
                     "end_year": 2026,
                     "reference_year_cycle": [2018],
                 },
+                "solver": "highs",
             }
         )
 
@@ -117,5 +121,6 @@ def test_invalid_end_year():
                     "end_year": 2024,
                     "reference_year_cycle": [2018],
                 },
+                "solver": "highs",
             }
         )


### PR DESCRIPTION
- initialises pypsa network with a snapshot based on the model start_year, end_year, and temporal granularity
- adds carriers to the network based on the fuel types in ecaa generators. At the moment the "AC" carrier is also added by hardcoding.
- adds buses to the network and if a demand trace is available for a bus, a load is also added and attached to the bus.
- adds lines to the network using just forward_direction_mw_summer_typical as a static forward and reverse flow limit. Reactance and resistance are set 1. All lines are added as AC carriers.
- adds ecaa generators to the network if the have a trace matching their name in the solar or wind trace directories then an availability trace is also added for the generator
- runs model using network.optimise()
- saves generator dispatch and lines flows as parquet files.
- takes about 7min to run one year on Nick's workstation