### PR TITLE
Logging and output management updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,10 +167,9 @@ scratch.py
 .~lock*.csv#
 
 # ispypsa ignores
-## CSVs in model_inputs
-model_data/**/*.csv
-model_data/**/*.parquet
-model_data/**/*.hdf5
+ispypsa_runs/**/*.csv
+ispypsa_runs/**/*.parquet
+ispypsa_runs/**/*.hdf5
 
 # ignore doit database
 .doit*

--- a/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
+++ b/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
@@ -1,3 +1,6 @@
+# The name of the ISPyPSA model run
+# This name is used to select the output folder within `ispypsa_runs`
+ispypsa_run_name: development
 # The ISP scenario for which to generate ISPyPSA inputs
 # Options (descriptions lifted from the 2024 ISP):
 #   "Progressive Change": Reflects slower economic growth and energy investment with

--- a/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
+++ b/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
@@ -25,8 +25,9 @@ network:
     #   "attached_to_parent_node": REZ resources are attached to their parent node (sub-region or NEM region)
     rezs: discrete_nodes
 traces:
-  # The path to the folder containing parsed demand, wind and solar traces
-  path_to_parsed_traces: /home/abi/isp-traces/parsed-traces/
+  # The path to the folder containing parsed demand, wind and solar traces. If set to ENV the path will be retrieved
+  # from the environment variable "PATH_TO_PARSED_TRACES"
+  path_to_parsed_traces: ENV
   year_type: fy
   start_year: 2025
   end_year: 2025

--- a/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
+++ b/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
@@ -25,6 +25,8 @@ network:
     #   "attached_to_parent_node": REZ resources are attached to their parent node (sub-region or NEM region)
     rezs: discrete_nodes
 traces:
+  # The path to the folder containing parsed demand, wind and solar traces
+  path_to_parsed_traces: /home/abi/isp-traces/parsed-traces/
   year_type: fy
   start_year: 2025
   end_year: 2025

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Literal
 
@@ -25,6 +26,11 @@ class TraceConfig(BaseModel):
     @field_validator("path_to_parsed_traces")
     @classmethod
     def validate_path_to_parsed_traces(cls, path_to_parsed_traces: str):
+        if path_to_parsed_traces == "ENV":
+            path_to_parsed_traces = os.environ.get("PATH_TO_PARSED_TRACES")
+            if path_to_parsed_traces is None:
+                raise ValueError("Environment variable PATH_TO_PARSED_TRACES not set")
+
         trace_path = Path(path_to_parsed_traces)
         if not trace_path.exists():
             raise NotADirectoryError(

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -31,6 +31,7 @@ class TraceConfig(BaseModel):
 
 
 class ModelConfig(BaseModel):
+    ispypsa_run_name: str
     scenario: Literal[tuple(_ISP_SCENARIOS)]
     operational_temporal_resolution_min: int
     network: NetworkConfig

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, field_validator
@@ -15,10 +16,29 @@ class NetworkConfig(BaseModel):
 
 
 class TraceConfig(BaseModel):
+    path_to_parsed_traces: str
     year_type: Literal["fy", "calendar"]
     start_year: int
     end_year: int
     reference_year_cycle: list[int]
+
+    @field_validator("path_to_parsed_traces")
+    @classmethod
+    def validate_path_to_parsed_traces(cls, path_to_parsed_traces: str):
+        trace_path = Path(path_to_parsed_traces)
+        if not trace_path.exists():
+            raise NotADirectoryError(
+                f"The parsed traces directory specified in the config ({trace_path})"
+                + " does not exist"
+            )
+        # check this folder contains sub-folders named solar, wind and demand
+        child_folders = set([folder.parts[-1] for folder in trace_path.iterdir()])
+        if child_folders != set(("demand", "wind", "solar")):
+            raise ValueError(
+                "The parsed traces directory must contain the following sub-folders"
+                + " with parsed trace data: 'demand', 'solar', 'wind'"
+            )
+        return path_to_parsed_traces
 
     @field_validator("end_year")
     @classmethod

--- a/src/ispypsa/logging.py
+++ b/src/ispypsa/logging.py
@@ -2,6 +2,13 @@ import logging
 import sys
 
 
+def configure_dependency_logger(name: str, level: int = logging.WARNING) -> None:
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.propagate = True
+    logger.setLevel(level)
+
+
 def configure_logging(
     console: bool = True,
     console_level: int = logging.WARNING,
@@ -40,3 +47,4 @@ def configure_logging(
         format="[%(asctime)s] %(levelname)s: %(message)s",
         handlers=handlers,
     )
+    configure_dependency_logger("pypsa", logging.INFO)

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -15,6 +15,7 @@ from ispypsa.config.validators import ModelConfig
 def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
     ModelConfig(
         **{
+            "ispypsa_run_name": "test",
             "scenario": scenario,
             "operational_temporal_resolution_min": 30,
             "network": {
@@ -38,6 +39,7 @@ def test_invalid_scenario():
     with pytest.raises(ValidationError):
         ModelConfig(
             **{
+                "ispypsa_run_name": "test",
                 "scenario": "BAU",
                 "operational_temporal_resolution_min": 30,
                 "network": {
@@ -61,6 +63,7 @@ def test_invalid_node_granularity():
     with pytest.raises(ValidationError):
         ModelConfig(
             **{
+                "ispypsa_run_name": "test",
                 "scenario": "Step Change",
                 "operational_temporal_resolution_min": 30,
                 "network": {
@@ -84,6 +87,7 @@ def test_invalid_nodes_rezs():
     with pytest.raises(ValidationError):
         ModelConfig(
             **{
+                "ispypsa_run_name": "test",
                 "scenario": "Step Change",
                 "operational_temporal_resolution_min": 30,
                 "network": {
@@ -107,6 +111,7 @@ def test_invalid_end_year():
     with pytest.raises(ValueError):
         ModelConfig(
             **{
+                "ispypsa_run_name": "test",
                 "scenario": "Step Change",
                 "operational_temporal_resolution_min": 30,
                 "network": {

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -111,6 +111,56 @@ def test_invalid_nodes_rezs():
         )
 
 
+def test_not_a_directory_parsed_traces_path():
+    with pytest.raises(NotADirectoryError):
+        ModelConfig(
+            **{
+                "ispypsa_run_name": "test",
+                "scenario": "Step Change",
+                "operational_temporal_resolution_min": 30,
+                "network": {
+                    "nodes": {
+                        "regional_granularity": "sub_regions",
+                        "rezs": "discrete_nodes",
+                    }
+                },
+                "traces": {
+                    "path_to_parsed_traces": "tests/wrong_traces",
+                    "year_type": "fy",
+                    "start_year": 2025,
+                    "end_year": 2026,
+                    "reference_year_cycle": [2018],
+                },
+                "solver": "highs",
+            }
+        )
+
+
+def test_invalid_parsed_traces_path():
+    with pytest.raises(ValueError):
+        ModelConfig(
+            **{
+                "ispypsa_run_name": "test",
+                "scenario": "Step Change",
+                "operational_temporal_resolution_min": 30,
+                "network": {
+                    "nodes": {
+                        "regional_granularity": "sub_regions",
+                        "rezs": "discrete_nodes",
+                    }
+                },
+                "traces": {
+                    "path_to_parsed_traces": "ispypsa_runs",
+                    "year_type": "fy",
+                    "start_year": 2025,
+                    "end_year": 2026,
+                    "reference_year_cycle": [2018],
+                },
+                "solver": "highs",
+            }
+        )
+
+
 def test_invalid_end_year():
     with pytest.raises(ValueError):
         ModelConfig(

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -25,6 +25,7 @@ def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
                 }
             },
             "traces": {
+                "path_to_parsed_traces": "tests/test_traces",
                 "year_type": year_type,
                 "start_year": 2025,
                 "end_year": 2026,
@@ -49,6 +50,7 @@ def test_invalid_scenario():
                     }
                 },
                 "traces": {
+                    "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
                     "end_year": 2026,
@@ -73,6 +75,7 @@ def test_invalid_node_granularity():
                     }
                 },
                 "traces": {
+                    "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
                     "end_year": 2026,
@@ -97,6 +100,7 @@ def test_invalid_nodes_rezs():
                     }
                 },
                 "traces": {
+                    "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
                     "end_year": 2026,
@@ -121,6 +125,7 @@ def test_invalid_end_year():
                     }
                 },
                 "traces": {
+                    "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
                     "end_year": 2024,

--- a/tests/test_traces/demand/.keep
+++ b/tests/test_traces/demand/.keep
@@ -1,0 +1,1 @@
+# This dummy file exists to ensure that the parent directory can be committed

--- a/tests/test_traces/solar/.keep
+++ b/tests/test_traces/solar/.keep
@@ -1,0 +1,1 @@
+# This dummy file exists to ensure that the parent directory can be committed

--- a/tests/test_traces/wind/.keep
+++ b/tests/test_traces/wind/.keep
@@ -1,0 +1,1 @@
+# This dummy file exists to ensure that the parent directory can be committed


### PR DESCRIPTION
# Logging
- PyPSA logger propagates base logger (i.e. ISPyPSA) settings

# Config
- Add `ispypsa_run_name`, which is used to specify an output folder containing the various output sub-folders such as `ispypsa_inputs`, `pypsa_friendly` and `outputs`
- Add `path_to_parsed_traces` to `traces` along with validation that checks the path is a folder and that it contains three sub-folders: `demand`, `solar` and `wind`

# Dodo.py
- Propagation of above changes
  - Now you need to specify a config path for a particular model run, and dodo will check deps etc for that model run 
- Cleaning outputs
  - if any of the "intermediate input"  or output generation tasks (i.e. everything except workbook table caching) is rerun, the task will first check if the output folder exists. 
    - If it doesn't, it will create it. 
    - If it does, it will delete the folder ensuring that intermediate output folders reflect the latest output