### PR TITLE
refactor snapshot creation and check trace data against snapshot

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -41,7 +41,7 @@ from ispypsa.translator.generators import (
     _translate_generator_timeseries,
 )
 from ispypsa.translator.lines import translate_flow_paths_to_lines
-from ispypsa.translator.snapshot import create_snapshot_index
+from ispypsa.translator.snapshot import create_complete_snapshot_index
 
 root_folder = Path("ispypsa_runs")
 
@@ -143,7 +143,7 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
 ) -> None:
     create_or_clean_task_output_folder(pypsa_inputs_location)
     pypsa_inputs = {}
-    pypsa_inputs["snapshot"] = create_snapshot_index(
+    pypsa_inputs["snapshot"] = create_complete_snapshot_index(
         start_year=config.temporal.start_year,
         end_year=config.temporal.end_year,
         operational_temporal_resolution_min=config.temporal.operational_temporal_resolution_min,

--- a/dodo.py
+++ b/dodo.py
@@ -56,7 +56,7 @@ run_folder = Path(root_folder, config.ispypsa_run_name)
 _PARSED_WORKBOOK_CACHE = root_folder / Path("workbook_table_cache")
 _ISPYPSA_INPUT_TABLES_DIRECTORY = Path(run_folder, "ispypsa_inputs", "tables")
 _PYPSA_FRIENDLY_DIRECTORY = Path(run_folder, "pypsa_friendly")
-_PARSED_TRACE_DIRECTORY = Path(config.traces.path_to_parsed_traces)
+_PARSED_TRACE_DIRECTORY = Path(config.temporal.path_to_parsed_traces)
 _PYPSA_OUTPUTS_DIRECTORY = Path(run_folder, "outputs")
 
 configure_logging()
@@ -144,10 +144,10 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
     create_or_clean_task_output_folder(pypsa_inputs_location)
     pypsa_inputs = {}
     pypsa_inputs["snapshot"] = create_snapshot_index(
-        start_year=config.traces.start_year,
-        end_year=config.traces.end_year,
-        operational_temporal_resolution_min=config.operational_temporal_resolution_min,
-        year_type=config.traces.year_type,
+        start_year=config.temporal.start_year,
+        end_year=config.temporal.end_year,
+        operational_temporal_resolution_min=config.temporal.operational_temporal_resolution_min,
+        year_type=config.temporal.year_type,
     )
     pypsa_inputs["generators"] = _translate_ecaa_generators(
         ispypsa_inputs_location, config.network.nodes.regional_granularity
@@ -161,9 +161,9 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
     for name, table in pypsa_inputs.items():
         table.to_csv(Path(pypsa_inputs_location, f"{name}.csv"))
     reference_year_mapping = construct_reference_year_mapping(
-        start_year=config.traces.start_year,
-        end_year=config.traces.end_year,
-        reference_years=config.traces.reference_year_cycle,
+        start_year=config.temporal.start_year,
+        end_year=config.temporal.end_year,
+        reference_years=config.temporal.reference_year_cycle,
     )
     _translate_generator_timeseries(
         ispypsa_inputs_location,
@@ -171,7 +171,7 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
         pypsa_inputs_location,
         generator_type="solar",
         reference_year_mapping=reference_year_mapping,
-        year_type=config.traces.year_type,
+        year_type=config.temporal.year_type,
         snapshot=pypsa_inputs["snapshot"],
     )
     _translate_generator_timeseries(
@@ -180,7 +180,7 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
         pypsa_inputs_location,
         generator_type="wind",
         reference_year_mapping=reference_year_mapping,
-        year_type=config.traces.year_type,
+        year_type=config.temporal.year_type,
         snapshot=pypsa_inputs["snapshot"],
     )
     _translate_buses_demand_timeseries(
@@ -190,7 +190,7 @@ def create_pypsa_inputs_from_config_and_ispypsa_inputs(
         scenario=config.scenario,
         regional_granularity=config.network.nodes.regional_granularity,
         reference_year_mapping=reference_year_mapping,
-        year_type=config.traces.year_type,
+        year_type=config.temporal.year_type,
         snapshot=pypsa_inputs["snapshot"],
     )
 

--- a/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
+++ b/ispypsa_runs/development/ispypsa_inputs/ispypsa_config.yaml
@@ -9,7 +9,6 @@ ispypsa_run_name: development
 #   "Step Change": Fulfils Australia’s emission reduction commitments in a growing economy
 #   "Green Energy Exports": Sees very strong industrial decarbonisation and low-emission energy exports
 scenario: Step Change
-operational_temporal_resolution_min: 30
 network:
   nodes:
     # The regional granularity of the nodes in the modelled network
@@ -24,7 +23,8 @@ network:
     #   "discrete_nodes": REZs are added as network nodes to model REZ transmission limits
     #   "attached_to_parent_node": REZ resources are attached to their parent node (sub-region or NEM region)
     rezs: discrete_nodes
-traces:
+temporal:
+  operational_temporal_resolution_min: 30
   # The path to the folder containing parsed demand, wind and solar traces. If set to ENV the path will be retrieved
   # from the environment variable "PATH_TO_PARSED_TRACES"
   path_to_parsed_traces: ENV

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -16,12 +16,31 @@ class NetworkConfig(BaseModel):
     nodes: NodesConfig
 
 
-class TraceConfig(BaseModel):
+class TemporalConfig(BaseModel):
+    operational_temporal_resolution_min: int
     path_to_parsed_traces: str
     year_type: Literal["fy", "calendar"]
     start_year: int
     end_year: int
     reference_year_cycle: list[int]
+
+    @field_validator("operational_temporal_resolution_min")
+    @classmethod
+    def validate_temporal_resolution_min(cls, operational_temporal_resolution_min: int):
+        # TODO properly implement temporal aggregation so this first check can be removed.
+        if operational_temporal_resolution_min != 30:
+            raise ValueError(
+                "config operational_temporal_resolution_min must equal 30 min"
+            )
+        if operational_temporal_resolution_min < 30:
+            raise ValueError(
+                "config operational_temporal_resolution_min must be greater than or equal to 30 min"
+            )
+        if (operational_temporal_resolution_min % 30) != 0:
+            raise ValueError(
+                "config operational_temporal_resolution_min must be multiple of 30 min"
+            )
+        return operational_temporal_resolution_min
 
     @field_validator("path_to_parsed_traces")
     @classmethod
@@ -59,9 +78,8 @@ class TraceConfig(BaseModel):
 class ModelConfig(BaseModel):
     ispypsa_run_name: str
     scenario: Literal[tuple(_ISP_SCENARIOS)]
-    operational_temporal_resolution_min: int
     network: NetworkConfig
-    traces: TraceConfig
+    temporal: TemporalConfig
     solver: Literal[
         "highs",
         "cbc",
@@ -75,21 +93,3 @@ class ModelConfig(BaseModel):
         "mindopt",
         "pips",
     ]
-
-    @field_validator("operational_temporal_resolution_min")
-    @classmethod
-    def validate_temporal_resolution_min(cls, operational_temporal_resolution_min: int):
-        # TODO properly implement temporal aggregation so this first check can be removed.
-        if operational_temporal_resolution_min != 30:
-            raise ValueError(
-                "config operational_temporal_resolution_min must equal 30 min"
-            )
-        if operational_temporal_resolution_min < 30:
-            raise ValueError(
-                "config operational_temporal_resolution_min must be greater than or equal to 30 min"
-            )
-        if (operational_temporal_resolution_min % 30) != 0:
-            raise ValueError(
-                "config operational_temporal_resolution_min must be multiple of 30 min"
-            )
-        return operational_temporal_resolution_min

--- a/src/ispypsa/model/buses.py
+++ b/src/ispypsa/model/buses.py
@@ -24,8 +24,6 @@ def _add_bus_to_network(
     demand_trace_path = path_to_demand_traces / Path(f"{bus_name}.parquet")
     if demand_trace_path.exists():
         demand = pd.read_parquet(demand_trace_path)
-        # datetime in nanoseconds required by PyPSA
-        demand["Datetime"] = demand["Datetime"].astype("datetime64[ns]")
         demand = demand.set_index("Datetime")
         network.add(
             class_name="Load",

--- a/src/ispypsa/model/generators.py
+++ b/src/ispypsa/model/generators.py
@@ -51,7 +51,6 @@ def _add_ecaa_generator_to_network(
         trace_data = None
 
     if trace_data is not None:
-        trace_data["Datetime"] = trace_data["Datetime"].astype("datetime64[ns]")
         generator_definition["p_max_pu"] = trace_data.set_index("Datetime")["Value"]
 
     network.add(**generator_definition)

--- a/src/ispypsa/model/initialise.py
+++ b/src/ispypsa/model/initialise.py
@@ -1,64 +1,22 @@
-from datetime import datetime
+from pathlib import Path
 
 import pandas as pd
 import pypsa
 
 
-def prepare_snapshot_index(
-    start_year: int,
-    end_year: int,
-    operational_temporal_resolution_min: int,
-    year_type: str,
-) -> pd.DatetimeIndex:
-    """Creates a DatetimeIndex defining the snapshots for the model.
-
-    The index will start at the beginning of `start_year` and finish at the end of
-    `end_year` with the specified temporal resolution.
-
-    Args:
-        start_year: the first year the model covers (i.e. inclusive)
-        end_year: the last year the model covers (i.e. inclusive)
-        year_type: The year type. 'fy' for financial years, and 'calendar' for calendar
-            years. For 'fy', `start_year` and `end_year` refer to the year  in which
-            the financial year ends.
-        operational_temporal_resolution_min: int defining the temporal resolution in minutes.
-    """
-    if year_type == "fy":
-        start_date = datetime(year=start_year - 1, month=7, day=1, hour=0, minute=30)
-        end_date = datetime(year=end_year, month=7, day=1, hour=0, minute=0)
-    else:
-        start_date = datetime(year=start_year, month=1, day=1, hour=0, minute=30)
-        end_date = datetime(year=end_year + 1, month=1, day=1, hour=0, minute=0)
-    time_index = pd.date_range(
-        start=start_date,
-        end=end_date,
-        freq=str(operational_temporal_resolution_min) + "min",
-    )
-    time_index.strftime("'%Y-%m-%d %H:%M:%S")
-    return time_index
-
-
-def initialise_network(
-    start_year: int,
-    end_year: int,
-    year_type: str,
-    operational_temporal_resolution_min: int,
-) -> pypsa.Network:
+def initialise_network(path_pypsa_inputs: Path) -> pypsa.Network:
     """Creates a `pypsa.Network object` with snapshots defined.
 
     Args:
-        start_year: the first year the model covers (i.e. inclusive)
-        end_year: the last year the model covers (i.e. inclusive)
-        year_type: The year type. 'fy' for financial years, and 'calendar' for calendar
-            years. For 'fy', `start_year` and `end_year` refer to the year  in which
-            the financial year ends.
-        operational_temporal_resolution_min: int defining the temporal resolution in minutes.
+        path_pypsa_inputs: `pathlib.Path` that points to the directory containing
+            PyPSA inputs
 
     Returns:
         `pypsa.Network` object
     """
-    time_index = prepare_snapshot_index(
-        start_year, end_year, operational_temporal_resolution_min, year_type
-    )
+    time_index = pd.read_csv(
+        path_pypsa_inputs / Path("snapshot.csv"), index_col=0
+    ).index
+    time_index = pd.to_datetime(time_index)
     network = pypsa.Network(snapshots=time_index)
     return network

--- a/src/ispypsa/translator/buses.py
+++ b/src/ispypsa/translator/buses.py
@@ -5,6 +5,7 @@ import pandas as pd
 from isp_trace_parser import get_data
 
 from ispypsa.translator.mappings import _BUS_ATTRIBUTES
+from ispypsa.translator.time_series_checker import check_time_series
 
 
 def _translate_nodes_to_buses(ispypsa_inputs_path: Path | str) -> pd.DataFrame:
@@ -34,6 +35,7 @@ def _translate_buses_demand_timeseries(
     regional_granularity: str,
     reference_year_mapping: dict[int:int],
     year_type: Literal["fy", "calendar"],
+    snapshot: pd.DataFrame,
 ) -> None:
     """Gets trace data for operational demand by constructing a timeseries from the
     start to end year using the reference year cycle provided.
@@ -51,6 +53,7 @@ def _translate_buses_demand_timeseries(
         year_type: str, 'fy' or 'calendar', if 'fy' then time filtering is by financial year with start_year and
             end_year specifiying the financial year to return data for, using year ending nomenclature (2016 ->
             FY2015/2016). If 'calendar', then filtering is by calendar year.
+        snapshot: pd.DataFrame containing the expected time series values.
 
     Returns:
         None
@@ -106,6 +109,14 @@ def _translate_buses_demand_timeseries(
                 node_traces.append(trace)
         node_traces = pd.concat(node_traces)
         node_trace = node_traces.groupby("Datetime", as_index=False)["Value"].sum()
+        # datetime in nanoseconds required by PyPSA
+        node_trace["Datetime"] = node_trace["Datetime"].astype("datetime64[ns]")
+        check_time_series(
+            node_trace["Datetime"],
+            pd.Series(snapshot.index),
+            "demand data",
+            demand_node,
+        )
         node_trace.to_parquet(
             Path(output_trace_path, f"{demand_node}.parquet"), index=False
         )

--- a/src/ispypsa/translator/generators.py
+++ b/src/ispypsa/translator/generators.py
@@ -5,6 +5,7 @@ import pandas as pd
 from isp_trace_parser import get_data
 
 from ispypsa.translator.mappings import _GENERATOR_ATTRIBUTES
+from ispypsa.translator.time_series_checker import check_time_series
 
 
 def _translate_ecaa_generators(
@@ -67,6 +68,7 @@ def _translate_generator_timeseries(
     generator_type: Literal["solar", "wind"],
     reference_year_mapping: dict[int:int],
     year_type: Literal["fy", "calendar"],
+    snapshot: pd.DataFrame,
 ) -> None:
     """Gets trace data for generators by constructing a timeseries from the start to end year using the reference year
     cycle provided. Trace data is then saved as a parquet file to .
@@ -80,6 +82,7 @@ def _translate_generator_timeseries(
         year_type: str, 'fy' or 'calendar', if 'fy' then time filtering is by financial year with start_year and
             end_year specifiying the financial year to return data for, using year ending nomenclature (2016 ->
             FY2015/2016). If 'calendar', then filtering is by calendar year.
+        snapshot: pd.DataFrame containing the expected time series values.
 
     Returns:
         None
@@ -111,5 +114,10 @@ def _translate_generator_timeseries(
             project=gen,
             directory=trace_data_path,
             year_type=year_type,
+        )
+        # datetime in nanoseconds required by PyPSA
+        trace["Datetime"] = trace["Datetime"].astype("datetime64[ns]")
+        check_time_series(
+            trace["Datetime"], pd.Series(snapshot.index), "generator trace data", gen
         )
         trace.to_parquet(Path(output_trace_path, f"{gen}.parquet"), index=False)

--- a/src/ispypsa/translator/snapshot.py
+++ b/src/ispypsa/translator/snapshot.py
@@ -21,11 +21,24 @@ def create_snapshot_index(
         pd.DataFrame
     """
     if year_type == "fy":
-        start_date = datetime(year=start_year - 1, month=7, day=1, hour=0, minute=30)
-        end_date = datetime(year=end_year, month=7, day=1, hour=0, minute=0)
+        start_year = start_year - 1
+        end_year = end_year
+        month = 7
     else:
-        start_date = datetime(year=start_year, month=1, day=1, hour=0, minute=30)
-        end_date = datetime(year=end_year + 1, month=1, day=1, hour=0, minute=0)
+        start_year = start_year
+        end_year = end_year + 1
+        month = 1
+
+    if operational_temporal_resolution_min < 60:
+        hour = 0
+        minute = operational_temporal_resolution_min
+    else:
+        hour = operational_temporal_resolution_min // 60
+        minute = operational_temporal_resolution_min % 60
+
+    start_date = datetime(year=start_year, month=month, day=1, hour=hour, minute=minute)
+    end_date = datetime(year=end_year, month=month, day=1, hour=0, minute=0)
+
     time_index = pd.date_range(
         start=start_date,
         end=end_date,

--- a/src/ispypsa/translator/snapshot.py
+++ b/src/ispypsa/translator/snapshot.py
@@ -15,7 +15,12 @@ def create_snapshot_index(
     `end_year` with the specified temporal resolution.
 
     Args:
-        ispypsa_inputs_path: Path to directory containing modelling input template CSVs.
+        start_year: int specifying the start year
+        end_year: int specifying the end year
+        operational_temporal_resolution_min: int specifying the snapshot temporal resolution in minutes
+        year_type: str specifying the year type 'fy' for financial year means that start_year and end_year refer to
+            the financial year ending in the given year, and calendar means start_year and end_year refer to
+            standard calendar years.
 
     Returns:
         pd.DataFrame

--- a/src/ispypsa/translator/snapshot.py
+++ b/src/ispypsa/translator/snapshot.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pandas as pd
 
 
-def create_snapshot_index(
+def create_complete_snapshot_index(
     start_year: int,
     end_year: int,
     operational_temporal_resolution_min: int,
@@ -18,7 +18,7 @@ def create_snapshot_index(
         start_year: int specifying the start year
         end_year: int specifying the end year
         operational_temporal_resolution_min: int specifying the snapshot temporal resolution in minutes
-        year_type: str specifying the year type 'fy' for financial year means that start_year and end_year refer to
+        year_type: str specifying the year type. 'fy' for financial year means that start_year and end_year refer to
             the financial year ending in the given year, and calendar means start_year and end_year refer to
             standard calendar years.
 

--- a/src/ispypsa/translator/snapshot.py
+++ b/src/ispypsa/translator/snapshot.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+import pandas as pd
+
+
+def create_snapshot_index(
+    start_year: int,
+    end_year: int,
+    operational_temporal_resolution_min: int,
+    year_type: str,
+) -> pd.DataFrame:
+    """Creates a DatetimeIndex, stored in DataFrame, defining the snapshots for the model before temporal aggregation.
+
+    The index will start at the beginning of `start_year` and finish at the end of
+    `end_year` with the specified temporal resolution.
+
+    Args:
+        ispypsa_inputs_path: Path to directory containing modelling input template CSVs.
+
+    Returns:
+        pd.DataFrame
+    """
+    if year_type == "fy":
+        start_date = datetime(year=start_year - 1, month=7, day=1, hour=0, minute=30)
+        end_date = datetime(year=end_year, month=7, day=1, hour=0, minute=0)
+    else:
+        start_date = datetime(year=start_year, month=1, day=1, hour=0, minute=30)
+        end_date = datetime(year=end_year + 1, month=1, day=1, hour=0, minute=0)
+    time_index = pd.date_range(
+        start=start_date,
+        end=end_date,
+        freq=str(operational_temporal_resolution_min) + "min",
+    )
+    time_index = pd.DataFrame(index=time_index)
+    return time_index

--- a/src/ispypsa/translator/time_series_checker.py
+++ b/src/ispypsa/translator/time_series_checker.py
@@ -1,0 +1,52 @@
+import pandas as pd
+
+
+def check_time_series(
+    time_series: pd.Series,
+    expected_time_series: pd.Series,
+    process_name: str,
+    table_name: str,
+):
+    """Compares a Datetime series against an expected Datetime series
+    and raises errors if the two series don't match.
+
+    Args:
+        time_series: pd.Series of type Datetime
+        expected_time_series: pd.Series of type Datetime
+        process_name: str, type of data being checked by higher level process
+        table_name: str, name of table that time_series comes from
+
+    Returns: None
+
+    Raises: ValueError if series don't match
+    """
+    # Check datetime units
+    time_unit = str(time_series.dtype)
+    expected_unit = str(expected_time_series.dtype)
+    if time_unit != expected_unit:
+        raise ValueError(
+            f"When processing {process_name}, time series for {table_name} had incorrect units. "
+            f"expected: {expected_unit}, got: {time_unit}"
+        )
+
+    extra = set(time_series) - set(expected_time_series)
+    if extra:
+        raise ValueError(
+            f"When processing {process_name}, unexpected time series values where found in {table_name}: {extra}"
+        )
+
+    missing = set(expected_time_series) - set(time_series)
+    if missing:
+        raise ValueError(
+            f"When processing {process_name}, expected time series values where missing from {table_name}: {missing}"
+        )
+
+    # Check if the order is different
+    if not time_series.equals(expected_time_series):
+        # Find first difference in order
+        for i, (val_a, val_b) in enumerate(zip(time_series, expected_time_series)):
+            if val_a != val_b:
+                raise ValueError(
+                    f"When processing {process_name}, time series for {table_name} did not have the expect order. Series differ in order at position {i}: "
+                    f"got={val_a}, expected={val_b}"
+                )

--- a/tests/config/test_pydantic_model_config.py
+++ b/tests/config/test_pydantic_model_config.py
@@ -17,14 +17,14 @@ def test_valid_config(scenario, regional_granularity, nodes_rezs, year_type):
         **{
             "ispypsa_run_name": "test",
             "scenario": scenario,
-            "operational_temporal_resolution_min": 30,
             "network": {
                 "nodes": {
                     "regional_granularity": regional_granularity,
                     "rezs": nodes_rezs,
                 }
             },
-            "traces": {
+            "temporal": {
+                "operational_temporal_resolution_min": 30,
                 "path_to_parsed_traces": "tests/test_traces",
                 "year_type": year_type,
                 "start_year": 2025,
@@ -42,14 +42,14 @@ def test_invalid_scenario():
             **{
                 "ispypsa_run_name": "test",
                 "scenario": "BAU",
-                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
                         "rezs": "discrete_nodes",
                     }
                 },
-                "traces": {
+                "temporal": {
+                    "operational_temporal_resolution_min": 30,
                     "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
@@ -67,14 +67,14 @@ def test_invalid_node_granularity():
             **{
                 "ispypsa_run_name": "test",
                 "scenario": "Step Change",
-                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "wastelands",
                         "rezs": "discrete_nodes",
                     }
                 },
-                "traces": {
+                "temporal": {
+                    "operational_temporal_resolution_min": 30,
                     "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
@@ -92,14 +92,14 @@ def test_invalid_nodes_rezs():
             **{
                 "ispypsa_run_name": "test",
                 "scenario": "Step Change",
-                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
                         "rezs": "attached_to_regions",
                     }
                 },
-                "traces": {
+                "temporal": {
+                    "operational_temporal_resolution_min": 30,
                     "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,
@@ -117,14 +117,14 @@ def test_not_a_directory_parsed_traces_path():
             **{
                 "ispypsa_run_name": "test",
                 "scenario": "Step Change",
-                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
                         "rezs": "discrete_nodes",
                     }
                 },
-                "traces": {
+                "temporal": {
+                    "operational_temporal_resolution_min": 30,
                     "path_to_parsed_traces": "tests/wrong_traces",
                     "year_type": "fy",
                     "start_year": 2025,
@@ -142,14 +142,14 @@ def test_invalid_parsed_traces_path():
             **{
                 "ispypsa_run_name": "test",
                 "scenario": "Step Change",
-                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
                         "rezs": "discrete_nodes",
                     }
                 },
-                "traces": {
+                "temporal": {
+                    "operational_temporal_resolution_min": 30,
                     "path_to_parsed_traces": "ispypsa_runs",
                     "year_type": "fy",
                     "start_year": 2025,
@@ -167,14 +167,14 @@ def test_invalid_end_year():
             **{
                 "ispypsa_run_name": "test",
                 "scenario": "Step Change",
-                "operational_temporal_resolution_min": 30,
                 "network": {
                     "nodes": {
                         "regional_granularity": "sub_regions",
                         "rezs": "discrete_nodes",
                     }
                 },
-                "traces": {
+                "temporal": {
+                    "operational_temporal_resolution_min": 30,
                     "path_to_parsed_traces": "tests/test_traces",
                     "year_type": "fy",
                     "start_year": 2025,

--- a/tests/test_model/test_initialise.py
+++ b/tests/test_model/test_initialise.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from ispypsa.model.initialise import initialise_network
-from ispypsa.translator.snapshot import create_snapshot_index
+from ispypsa.translator.snapshot import create_complete_snapshot_index
 from ispypsa.translator.time_series_checker import check_time_series
 
 
 def test_network_initialisation(tmp_path):
-    snapshot = create_snapshot_index(
+    snapshot = create_complete_snapshot_index(
         start_year=2020,
         end_year=2020,
         operational_temporal_resolution_min=30,

--- a/tests/test_model/test_initialise.py
+++ b/tests/test_model/test_initialise.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from ispypsa.translator.snapshot import create_snapshot_index
+from ispypsa.translator.time_series_checker import check_time_series
+from ispypsa.model.initialise import initialise_network
+
+
+def test_network_initialisation(tmp_path):
+    snapshot = create_snapshot_index(
+        start_year=2020,
+        end_year=2020,
+        operational_temporal_resolution_min=30,
+        year_type="fy",
+    )
+    snapshot.to_csv(Path(tmp_path, "snapshot.csv"))
+    network = initialise_network(Path(tmp_path))
+    check_time_series(network.snapshots, snapshot.index, "", "")

--- a/tests/test_model/test_initialise.py
+++ b/tests/test_model/test_initialise.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
+from ispypsa.model.initialise import initialise_network
 from ispypsa.translator.snapshot import create_snapshot_index
 from ispypsa.translator.time_series_checker import check_time_series
-from ispypsa.model.initialise import initialise_network
 
 
 def test_network_initialisation(tmp_path):

--- a/tests/test_translator/test_snapshot.py
+++ b/tests/test_translator/test_snapshot.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from ispypsa.translator.snapshot import create_snapshot_index
+from ispypsa.translator.snapshot import create_complete_snapshot_index
 
 
 @pytest.mark.parametrize(
@@ -119,7 +119,7 @@ def test_snapshot_creation(
     expected_last_datetime: datetime,
     expected_length: int,
 ):
-    snapshot = create_snapshot_index(
+    snapshot = create_complete_snapshot_index(
         start_year=start_year,
         end_year=end_year,
         year_type=year_type,

--- a/tests/test_translator/test_snapshot.py
+++ b/tests/test_translator/test_snapshot.py
@@ -1,0 +1,129 @@
+import pytest
+from datetime import datetime
+
+from ispypsa.translator.snapshot import create_snapshot_index
+
+
+@pytest.mark.parametrize(
+    "start_year,end_year, year_type, operational_temporal_resolution_min, expected_first_datetime, expected_last_datetime, expected_length",
+    [
+        # One financial year with half hour resolution
+        (
+            2021,
+            2021,
+            "fy",
+            30,
+            datetime(year=2020, month=7, day=1, minute=30),
+            datetime(year=2021, month=7, day=1, minute=0),
+            8760 * 2,
+        ),
+        # One financial year with hourly resolution
+        (
+            2021,
+            2021,
+            "fy",
+            60,
+            datetime(year=2020, month=7, day=1, hour=1, minute=0),
+            datetime(year=2021, month=7, day=1, minute=0),
+            8760,
+        ),
+        # One financial year with four hourly resolution
+        (
+            2021,
+            2021,
+            "fy",
+            240,
+            datetime(year=2020, month=7, day=1, hour=4, minute=0),
+            datetime(year=2021, month=7, day=1, minute=0),
+            8760 / 4,
+        ),
+        # One financial year with fifteen minute resolution
+        (
+            2021,
+            2021,
+            "fy",
+            15,
+            datetime(year=2020, month=7, day=1, hour=0, minute=15),
+            datetime(year=2021, month=7, day=1, minute=0),
+            8760 * 4,
+        ),
+        # Three financial years with half hour resolution
+        (
+            2021,
+            2023,
+            "fy",
+            30,
+            datetime(year=2020, month=7, day=1, minute=30),
+            datetime(year=2023, month=7, day=1, minute=0),
+            8760 * 2 * 3,
+        ),
+        # One calendar year with half hour resolution
+        (
+            2021,
+            2021,
+            "calendar",
+            30,
+            datetime(year=2021, month=1, day=1, minute=30),
+            datetime(year=2022, month=1, day=1, minute=0),
+            8760 * 2,
+        ),
+        # One calendar year with hourly resolution
+        (
+            2021,
+            2021,
+            "calendar",
+            60,
+            datetime(year=2021, month=1, day=1, hour=1, minute=0),
+            datetime(year=2022, month=1, day=1, minute=0),
+            8760,
+        ),
+        # One calendar year with four hourly resolution
+        (
+            2021,
+            2021,
+            "calendar",
+            240,
+            datetime(year=2021, month=1, day=1, hour=4, minute=0),
+            datetime(year=2022, month=1, day=1, minute=0),
+            8760 / 4,
+        ),
+        # One calendar year with fifteen minute resolution
+        (
+            2021,
+            2021,
+            "calendar",
+            15,
+            datetime(year=2021, month=1, day=1, hour=0, minute=15),
+            datetime(year=2022, month=1, day=1, minute=0),
+            8760 * 4,
+        ),
+        # Three calendar year with half hour resolution
+        (
+            2021,
+            2023,
+            "calendar",
+            30,
+            datetime(year=2021, month=1, day=1, minute=30),
+            datetime(year=2024, month=1, day=1, minute=0),
+            8760 * 2 * 3,
+        ),
+    ],
+)
+def test_snapshot_creation(
+    start_year: int,
+    end_year: int,
+    year_type: str,
+    operational_temporal_resolution_min: int,
+    expected_first_datetime: datetime,
+    expected_last_datetime: datetime,
+    expected_length: int,
+):
+    snapshot = create_snapshot_index(
+        start_year=start_year,
+        end_year=end_year,
+        year_type=year_type,
+        operational_temporal_resolution_min=operational_temporal_resolution_min,
+    )
+    # assert snapshot.index[0] == expected_first_datetime
+    assert snapshot.index[-1] == expected_last_datetime
+    assert len(snapshot) == expected_length

--- a/tests/test_translator/test_snapshot.py
+++ b/tests/test_translator/test_snapshot.py
@@ -1,5 +1,6 @@
-import pytest
 from datetime import datetime
+
+import pytest
 
 from ispypsa.translator.snapshot import create_snapshot_index
 

--- a/tests/test_translator/test_time_series_checker.py
+++ b/tests/test_translator/test_time_series_checker.py
@@ -1,5 +1,5 @@
-import pytest
 import pandas as pd
+import pytest
 
 from ispypsa.translator.time_series_checker import check_time_series
 

--- a/tests/test_translator/test_time_series_checker.py
+++ b/tests/test_translator/test_time_series_checker.py
@@ -1,0 +1,112 @@
+import pytest
+import pandas as pd
+
+from ispypsa.translator.time_series_checker import check_time_series
+
+
+def test_identical_series_passes():
+    """Test that identical series pass validation"""
+    series_a = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 13:00:00"),
+            pd.Timestamp("2024-01-01 14:00:00"),
+            pd.Timestamp("2024-01-01 15:00:00"),
+            pd.Timestamp("2024-01-01 16:00:00"),
+        ]
+    )
+    series_b = series_a.copy()
+
+    # Should not raise any exceptions
+    check_time_series(series_a, series_b, "time_process", "measurements")
+
+
+def test_extra_values_raises_error():
+    """Test that extra values in time_series raises ValueError"""
+    expected = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 13:00:00"),
+            pd.Timestamp("2024-01-01 14:00:00"),
+        ]
+    )
+    actual = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 13:00:00"),
+            pd.Timestamp("2024-01-01 14:00:00"),
+            pd.Timestamp("2024-01-01 15:00:00"),  # Extra value
+        ]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        check_time_series(actual, expected, "time_process", "measurements")
+
+    assert "unexpected time series values" in str(exc_info.value)
+    assert "15:00:00" in str(exc_info.value)
+
+
+def test_missing_values_raises_error():
+    """Test that missing values in time_series raises ValueError"""
+    expected = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 13:00:00"),
+            pd.Timestamp("2024-01-01 14:00:00"),
+        ]
+    )
+    actual = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 13:00:00"),  # Missing last value
+        ]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        check_time_series(actual, expected, "time_process", "measurements")
+
+    assert "expected time series values where missing" in str(exc_info.value)
+    assert "14:00:00" in str(exc_info.value)
+
+
+def test_different_order_raises_error():
+    """Test that different order raises ValueError"""
+    expected = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 13:00:00"),
+            pd.Timestamp("2024-01-01 14:00:00"),
+        ]
+    )
+    actual = pd.Series(
+        [
+            pd.Timestamp("2024-01-01 13:00:00"),  # Swapped order
+            pd.Timestamp("2024-01-01 12:00:00"),
+            pd.Timestamp("2024-01-01 14:00:00"),
+        ]
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        check_time_series(actual, expected, "time_process", "measurements")
+
+    assert "did not have the expect order" in str(exc_info.value)
+    assert "13:00:00" in str(exc_info.value)
+    assert "12:00:00" in str(exc_info.value)
+
+
+def test_different_units_raises_error():
+    """Test that different datetime units raise ValueError"""
+    expected = pd.Series(
+        [pd.Timestamp("2024-01-01 12:00:00"), pd.Timestamp("2024-01-01 13:00:00")]
+    ).astype("datetime64[s]")
+
+    actual = pd.Series(
+        [pd.Timestamp("2024-01-01 12:00:00"), pd.Timestamp("2024-01-01 13:00:00")]
+    ).astype("datetime64[ms]")
+
+    with pytest.raises(ValueError) as exc_info:
+        check_time_series(actual, expected, "time_process", "measurements")
+
+    assert "incorrect units" in str(exc_info.value)
+    assert "datetime64[s]" in str(exc_info.value)
+    assert "datetime64[ms]" in str(exc_info.value)


### PR DESCRIPTION
- snapshot definition is moved to the translator
- conversion to 'ns' datetime units for traces is moved to the translator
- functionality added to check traces against snapshot before they are saved by the translator
- Also changes config structure so all config inputs related to temporality sit under the 'temporal' key 