### PR TITLE
Add initial set of generation and storage schemas

### DIFF
--- a/src/ispypsa/validation/schemas/costs_connection.yaml
+++ b/src/ispypsa/validation/schemas/costs_connection.yaml
@@ -1,0 +1,62 @@
+table: costs_connection
+required: false
+unique:
+  - [geo_id, technology, year]
+description: >
+  Connection costs and system security costs for new entrant generators and storage.
+
+  Contains additional costs for grid connection and, where applicable, system
+  strength requirements for inverter-based resources.
+
+  Source tables:
+    - `connection_cost_forecast_wind_and_solar`
+    - `connection_cost_forecast_other`
+
+  If absent: no additional connection or system security costs apply to new entrant
+  build costs.
+columns:
+  geo_id:
+    type: string
+    required: true
+    allowed_values_from:
+      table: network_geography
+      column: geo_id
+    description: >
+      Network geography identifier where the connection cost applies.
+
+      If costs are given by region in source data, create separate rows for each
+      geo_id in the region with the same cost.
+  technology:
+    type: string
+    required: true
+    description: >
+      Standardised technology name mapping to new entrant technologies in
+      `generators_new_entrant` and/or `storage_new_entrant` tables.
+
+      If blank: treat as geo_id-level VRE connection cost.
+  year:
+    type: int
+    required: true
+    description: >
+      Financial year in which this cost applies.
+
+      Used to map to new entrant storage/generation by build year.
+  connection_cost:
+    type: float
+    required: true
+    units: $/MW
+    description: >
+      Additional cost for new build reflecting transmission infrastructure required
+      for grid connection (AUD). Must be >= $0.0.
+  system_strength_cost:
+    type: float
+    required: false
+    units: $/MW
+    description: >
+      Additional cost for inverter-based resources to meet efficient levels of
+      system strength (AUD). Must be >= $0.0 or blank (assumed $0.0).
+
+      Per IASR: "This cost is a blend of remediation with synchronous condenser
+      and grid forming batteries".
+
+      If absent: only `connection_cost` is added to new entrant build cost.

--- a/src/ispypsa/validation/schemas/costs_connection.yaml
+++ b/src/ispypsa/validation/schemas/costs_connection.yaml
@@ -11,52 +11,67 @@ description: >
   Source tables:
     - `connection_cost_forecast_wind_and_solar`
     - `connection_cost_forecast_other`
+    - `connection_costs_for_wind_and_solar`
+    - `connection_costs_other`
+    - `efficient_level_of_system_strength_cost`
 
-  If absent: no additional connection or system security costs apply to new entrant
-  build costs.
+  If absent:
+  No additional connection or system security costs apply to new entrant build costs.
 columns:
   geo_id:
     type: string
     required: true
     allowed_values_from:
-      table: network_geography
-      column: geo_id
+      - network_geography: geo_id
     description: >
       Network geography identifier where the connection cost applies.
 
-      If costs are given by region in source data, create separate rows for each
-      geo_id in the region with the same cost.
+      Source notes:
+      If costs are given by region in source data, separate rows for each geo_id in
+      the region are created by the `templater` with the same cost applied across each.
   technology:
     type: string
-    required: true
+    required: false
+    allowed_values_from:
+      - costs_new_entrant_build: technology
     description: >
-      Standardised technology name mapping to new entrant technologies in
-      `generators_new_entrant` and/or `storage_new_entrant` tables.
+      Standardised technology name mapping to new entrant technologies.
 
-      If blank: treat as geo_id-level VRE connection cost.
+      If absent (or empty):
+      The connection cost applies to all new entrant technologies in `geo_id` that
+      have no technology-specific connection cost for the applicable year.
   year:
     type: int
     required: true
-    description: >
-      Financial year in which this cost applies.
-
-      Used to map to new entrant storage/generation by build year.
+    description: Year in which this cost applies.
   connection_cost:
     type: float
-    required: true
+    required: false
     units: $/MW
+    gte: 0.0
+    nan_fill: 0.0
     description: >
-      Additional cost for new build reflecting transmission infrastructure required
-      for grid connection (AUD). Must be >= $0.0.
+      Additional cost in AUD for new build reflecting transmission infrastructure required
+      for grid connection.
+
+      Used in calculating the total capital cost of new entrant technologies.
+
+      If absent (or empty):
+      No additional connection cost applies for the corresponding technology, geo_id
+      and build year.
   system_strength_cost:
     type: float
     required: false
     units: $/MW
+    gte: 0.0
+    nan_fill: 0.0
     description: >
-      Additional cost for inverter-based resources to meet efficient levels of
-      system strength (AUD). Must be >= $0.0 or blank (assumed $0.0).
+      Additional cost in AUD for inverter-based resources to meet efficient levels of
+      system strength.
 
-      Per IASR: "This cost is a blend of remediation with synchronous condenser
-      and grid forming batteries".
+      Used in calculating the total capital cost for some new entrant technologies.
+      Per IASR, "This cost is a blend of remediation with synchronous condenser
+      and grid forming batteries" (IASR workbook v7.5, 'Power System Security' sheet).
 
-      If absent: only `connection_cost` is added to new entrant build cost.
+      If absent (or empty):
+      Only the `connection_cost` value is added to new entrant build costs.

--- a/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
+++ b/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
@@ -1,0 +1,47 @@
+table: costs_fuel_prices
+required: false
+unique:
+  - [fuel_type, fuel_price_node, year]
+description: >
+  Fuel prices by year for generation and storage units.
+
+  Contains fuel prices used to calculate dynamic marginal costs for thermal generators.
+
+  Source tables:
+    - `coal_fuel_price`
+    - `biomass_fuel_price`
+    - `gas_and_liquid_fuel_prices_consultant_scenario_mapping`
+    - `gas_prices_existing_generators`
+    - `gas_prices_new_entrants`
+    - `liquid_fuel_prices`
+    - `gpg_secondary_fuel_prices` # maybe
+    - `hydrogen_prices`
+    - `biomethane_prices`
+  The consultant scenario mapping table is needed to map between specified ISP
+  scenario names and the gas, liquid fuel, hydrogen and biomenthane price scenario
+  names. This is new in the 2026 ISP (IASR v7.5).
+
+  If absent: no dynamic marginal costs calculated. Requires later user input of
+  fixed or dynamic marginal cost.
+columns:
+  fuel_type:
+    type: string
+    required: true
+    description: Fuel type used by the generator or storage unit.
+  fuel_price_node:
+    type: string
+    required: true
+    description: >
+      Identifier mapping to specific assets or sets of new entrant assets.
+
+      For existing and planned generation/storage, maps to specific power stations.
+      For new entrants, maps to technology/location groups.
+  year:
+    type: int
+    required: true
+    description: Financial year for which the price applies.
+  price:
+    type: float
+    required: true
+    units: $/GJ
+    description: Fuel price in AUD per gigajoule.

--- a/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
+++ b/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
@@ -1,5 +1,12 @@
 table: costs_fuel_prices
-required: false
+# note: this table is required to calculate SRMC. Possible to make this optional in
+# future and/or design in more flexibility around dynamic vs. static SRMC calculation
+# - but I'm getting blocked on how to implement this at the moment with some
+# complexity around VRE vs non-VRE data requirements and how validation will
+# be applied (to make some decisions around how conditional requirements can
+# work) - basically needs more thought/discussion so for now I'm making all
+# columns/tables needed to calculate SRMC (dynamic) required.
+required: true
 unique:
   - [fuel_type, fuel_price_node, year]
 description: >
@@ -17,31 +24,45 @@ description: >
     - `gpg_secondary_fuel_prices` # maybe
     - `hydrogen_prices`
     - `biomethane_prices`
-  The consultant scenario mapping table is needed to map between specified ISP
+
+  Source notes:
+  The consultant scenario mapping table is used to map between specified ISP
   scenario names and the gas, liquid fuel, hydrogen and biomenthane price scenario
   names. This is new in the 2026 ISP (IASR v7.5).
 
-  If absent: no dynamic marginal costs calculated. Requires later user input of
-  fixed or dynamic marginal cost.
+  Rows are also added by the `templater` for VRE fuels (Wind, Solar) with a price
+  of $0.0 for all years.
 columns:
   fuel_type:
     type: string
     required: true
-    description: Fuel type used by the generator or storage unit.
-  fuel_price_node:
+    allowed_values: ["Black Coal", "Brown Coal", "Liquid Fuel", "Gas", "Water", "Solar", "Wind", "Biomass", "Biomethane"]
+    description: >
+      Fuel type for which the price applies.
+
+      There are some fuel types (e.g., Biomethane) that are not used directly by any
+      generators in the model, but are used to blend with other fuels to calculate
+      final fuel costs.
+  fuel_price_mapping:
     type: string
     required: true
     description: >
       Identifier mapping to specific assets or sets of new entrant assets.
 
-      For existing and planned generation/storage, maps to specific power stations.
+      For most existing and planned generation, maps to specific power stations.
       For new entrants, maps to technology/location groups.
+
+      Source notes:
+      For purely 'blending' fuels (e.g. Biomethane) and VRE fuel types (Wind, Solar),
+      that don't map to a specific generator, technology, or location this column is
+      filled by the `templater` with the corresponding `fuel_type` value.
   year:
     type: int
     required: true
-    description: Financial year for which the price applies.
+    description: Year for which the price applies.
   price:
     type: float
     required: true
     units: $/GJ
+    gte: 0.0
     description: Fuel price in AUD per gigajoule.

--- a/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
+++ b/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
@@ -36,7 +36,6 @@ columns:
   fuel_type:
     type: string
     required: true
-    allowed_values: ["Black Coal", "Brown Coal", "Liquid Fuel", "Gas", "Water", "Solar", "Wind", "Biomass", "Biomethane"]
     description: >
       Fuel type for which the price applies.
 

--- a/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
+++ b/src/ispypsa/validation/schemas/costs_fuel_prices.yaml
@@ -8,7 +8,7 @@ table: costs_fuel_prices
 # columns/tables needed to calculate SRMC (dynamic) required.
 required: true
 unique:
-  - [fuel_type, fuel_price_node, year]
+  - [fuel_type, fuel_price_mapping, year]
 description: >
   Fuel prices by year for generation and storage units.
 

--- a/src/ispypsa/validation/schemas/costs_new_entrant_build.yaml
+++ b/src/ispypsa/validation/schemas/costs_new_entrant_build.yaml
@@ -1,0 +1,44 @@
+table: costs_new_entrant_build
+required: false
+custom_validation:
+  - name: conditional_required_build_costs
+    description: >
+      If new entrant generation or storage asset tables are present and non-empty,
+      build costs must also be provided for all technologies in those tables.
+unique:
+  - [technology, year]
+description: >
+  New entrant generation and storage unit build costs.
+
+  Contains upfront capital costs for new entrant technologies. For offshore wind,
+  build costs include connection costs if sourced from the IASR workbook.
+
+  Source tables:
+    - `build_costs`
+
+  Conditionally required: if new entrant generation or storage asset tables are
+  present and non-empty, build costs must be provided.
+columns:
+  technology:
+    type: string
+    required: true
+    description: >
+      Standardised technology name for the new entrant technology.
+
+      Should match technology values in `generators_new_entrant` or
+      `storage_new_entrant` tables.
+  year:
+    type: int
+    required: true
+    description: Financial year in which the build cost applies.
+  cost:
+    type: float
+    required: true
+    units: $/MW
+    description: >
+      Upfront capital cost to build the new entrant technology (AUD). Should be >= $0.0.
+
+      Does not include connection costs (except for offshore wind) or additional
+      costs for required REZ expansion, which are applied as penalties based on
+      build limits. Does not include locational cost factor scaling or first-of-a-kind
+      premium.

--- a/src/ispypsa/validation/schemas/costs_new_entrant_build.yaml
+++ b/src/ispypsa/validation/schemas/costs_new_entrant_build.yaml
@@ -1,6 +1,8 @@
 table: costs_new_entrant_build
 required: false
 custom_validation:
+  # note: depending on how validation is implemented - this might be unnecessary
+  # due to `allowed_values_from` condition defined in *_new_entrant tables?
   - name: conditional_required_build_costs
     description: >
       If new entrant generation or storage asset tables are present and non-empty,
@@ -16,8 +18,8 @@ description: >
   Source tables:
     - `build_costs`
 
-  Conditionally required: if new entrant generation or storage asset tables are
-  present and non-empty, build costs must be provided.
+  This table is required if new entrant generation or storage asset tables are
+  present and non-empty.
 columns:
   technology:
     type: string
@@ -25,18 +27,20 @@ columns:
     description: >
       Standardised technology name for the new entrant technology.
 
-      Should match technology values in `generators_new_entrant` or
-      `storage_new_entrant` tables.
+      Should match technology values in `generators_new_entrant` or `storage_new_entrant`
+      tables; any new entrant technology defined there must also have a build cost
+      in this table.
   year:
     type: int
     required: true
-    description: Financial year in which the build cost applies.
+    description: Year in which the build cost applies.
   cost:
     type: float
     required: true
+    gte: 0.0
     units: $/MW
     description: >
-      Upfront capital cost to build the new entrant technology (AUD). Should be >= $0.0.
+      Upfront capital cost in AUD to build the new entrant technology.
 
       Does not include connection costs (except for offshore wind) or additional
       costs for required REZ expansion, which are applied as penalties based on

--- a/src/ispypsa/validation/schemas/costs_new_entrant_build.yaml
+++ b/src/ispypsa/validation/schemas/costs_new_entrant_build.yaml
@@ -1,12 +1,5 @@
 table: costs_new_entrant_build
 required: false
-custom_validation:
-  # note: depending on how validation is implemented - this might be unnecessary
-  # due to `allowed_values_from` condition defined in *_new_entrant tables?
-  - name: conditional_required_build_costs
-    description: >
-      If new entrant generation or storage asset tables are present and non-empty,
-      build costs must also be provided for all technologies in those tables.
 unique:
   - [technology, year]
 description: >

--- a/src/ispypsa/validation/schemas/emissions_reduction.yaml
+++ b/src/ispypsa/validation/schemas/emissions_reduction.yaml
@@ -1,0 +1,50 @@
+table: emissions_reduction
+required: false
+unique:
+  - [fuel_type, name, year]
+description: >
+  Emissions intensity factors from fuel blending for gas-fired generators.
+
+  Contains estimated emissions factors reached through blending biomethane or
+  alternative fuels into the gas network, applied to individual gas-fired generators.
+
+  Source tables:
+    - `gpg_emissions_reduction_biomethane`
+
+  If absent: no fuel blending assumed, so no adjustments to fuel price or emissions
+  intensity for gas generators.
+columns:
+  fuel_type:
+    type: string
+    required: true
+    description: >
+      Fuel type blended into the gas network.
+
+      Should match fuel_type values in `generators_existing_planned` or
+      `generators_new_entrant` tables.
+  name:
+    type: string
+    required: false
+    description: >
+      Power station name to which this fuel blending applies.
+
+      Should match power_station values in `generators_existing_planned` or
+      `generators_new_entrant` tables.
+
+      If absent: blend rate applies to all generating units that use "Gas" fuel_type.
+  year:
+    type: int
+    required: true
+    description: Financial year in which this blend rate applies.
+  gpg_emissions_factor:
+    type: float
+    required: true
+    units: '%'
+    description: >
+      Emissions factor of gas-powered generation reached through fuel blending (%).
+      Must be between 0.0 and 100.0.
+
+      Used to calculate blended fuel prices and emissions intensity for GPG. Note:
+      simplified calculation assumes this factor applies directly to fuel price,
+      though biomethane has a small emissions contribution (0.13 kgCO2e/GJ). The
+      difference is negligible (<0.01%).

--- a/src/ispypsa/validation/schemas/emissions_reduction.yaml
+++ b/src/ispypsa/validation/schemas/emissions_reduction.yaml
@@ -11,27 +11,17 @@ description: >
   Source tables:
     - `gpg_emissions_reduction_biomethane`
 
-  If absent: no fuel blending assumed, so no adjustments to fuel price or emissions
-  intensity for gas generators.
+  If absent:
+  No fuel blending assumed, so no adjustments to fuel price or emissions intensity
+  for gas generators are considered in the model.
 columns:
   fuel_type:
     type: string
     required: true
+    allowed_values_from:
+      - costs_fuel_prices: fuel_type
     description: >
-      Fuel type blended into the gas network.
-
-      Should match fuel_type values in `generators_existing_planned` or
-      `generators_new_entrant` tables.
-  name:
-    type: string
-    required: false
-    description: >
-      Power station name to which this fuel blending applies.
-
-      Should match power_station values in `generators_existing_planned` or
-      `generators_new_entrant` tables.
-
-      If absent: blend rate applies to all generating units that use "Gas" fuel_type.
+      Fuel type blended into the base "Gas" fuel.
   year:
     type: int
     required: true
@@ -40,9 +30,10 @@ columns:
     type: float
     required: true
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
       Emissions factor of gas-powered generation reached through fuel blending (%).
-      Must be between 0.0 and 100.0.
 
       Used to calculate blended fuel prices and emissions intensity for GPG. Note:
       simplified calculation assumes this factor applies directly to fuel price,

--- a/src/ispypsa/validation/schemas/emissions_reduction.yaml
+++ b/src/ispypsa/validation/schemas/emissions_reduction.yaml
@@ -25,7 +25,7 @@ columns:
   year:
     type: int
     required: true
-    description: Financial year in which this blend rate applies.
+    description: Year in which this blend rate applies.
   gpg_emissions_factor:
     type: float
     required: true

--- a/src/ispypsa/validation/schemas/generators_existing_planned.yaml
+++ b/src/ispypsa/validation/schemas/generators_existing_planned.yaml
@@ -1,0 +1,146 @@
+table: generators_existing_planned
+required: false
+unique:
+  - [name]
+optional_sets:
+  - [fuel_price_node, vom, heat_rate] # All required if dynamic marginal costs are to be calculated
+description: >
+  Existing and planned-build generator characteristic data by generating unit.
+
+  Summary data for all existing and planned-build (in ISP terminology, this includes
+  committed, anticipated and additional policy-supported) generators, with each row
+  containing information to represent a single generating unit.
+
+  Source IASR tables:
+    - `existing_committed_anticipated_additional_generator_summary`
+    - `renewable_energy_zones`
+    - `fixed_opex_existing_committed_anticipated_additional_generators`
+    - `variable_opex_existing_committed_anticipated_additional_generators`
+    - `heat_rates_existing_committed_anticipated_additional_generators`
+    - `maximum_capacity_existing_committed_anticipated_additional_generators`
+    - `expected_closure_years`
+    - `gpg_min_stable_level_existing_generators`
+    - `coal_minimum_stable_level`
+
+  If absent: a greenfield model will be run - no existing generators will be considered
+  and built in the model.
+columns:
+  name:
+    type: string
+    required: true
+    description: The name of the generating unit, e.g. DUID or full name. Must be unique.
+  power_station:
+    type: string
+    required: true
+    description: >
+      The name of the power station to which the generating unit belongs.
+
+      This should be the full proper name of the power station. In cases where only
+      one generating unit falls into a power station, this may have the same value
+      as the `name` column. This value is used to group units of generators in results
+      and charts, and map to station-level data, e.g. fuel costs.
+  technology:
+    type: string
+    required: true
+    description: >
+      The full proper name of the technology type as given in the IASR workbook.
+
+      Values in this column are used as 'canon' technology types across the model -
+      i.e. used to correct typos or map different spellings to a single canonical value.
+      This column is also used to group results by technology type, and maps directly to
+      the 'Retirement Costs' table in the IASR workbook (not currently implemented).
+  geo_id:
+    type: string
+    required: true
+    allowed_values_from:
+      table: network_geography
+      column: geo_id
+    description: The geography identifier to which the generating unit is connected.
+  fuel_type:
+    type: string
+    required: true
+    description: >
+      The name of the type of fuel used by the generating unit.
+
+      This column is used to define the `carrier` for the generating unit in the
+      PyPSA model, and to map to fuel prices.
+  fuel_price_node:
+    type: string
+    required: false
+    description: >
+      The power station name or other identifier used to map fuel prices to the generator.
+
+      Note: for all power stations except for Kogan Gas, this should exactly match
+      the `power_station` column.
+
+      If absent: assume no dynamic marginal price is calculated for this model run.
+  fom:
+    type: float
+    required: false
+    units: $/MW/year
+    description: >
+      Fixed operation and maintenance cost per unit of capacity per year.
+
+      All values should be in AUD and >= $0.0 if present. In the 2026 ISP for
+      existing and planned generating units, this value would be used to determine
+      retirement schedules based on a revenue sufficiency criterion; this is not
+      yet implemented here.
+
+      If absent: no change.
+  vom:
+    type: float
+    required: false
+    units: $/MWh
+    description: >
+      Variable operation and maintenance cost per unit of energy produced, not including fuel cost.
+
+      All values should be in AUD and >= $0.0 if present. These values are used to
+      calculate the short-run marginal cost of generation for a given unit.
+
+      If absent: assume no dynamic marginal price is calculated for this model run.
+  heat_rate:
+    type: float
+    required: false
+    units: GJ/MWh
+    description: >
+      The heat rate of the generating unit, used to calculate the fuel cost per unit
+      of energy produced.
+
+      All values should be >= 0.0 if present. These values are used to
+      calculate the short-run marginal cost of generation for a given unit.
+
+      If absent: assume no dynamic marginal price is calculated for this model run.
+  capacity:
+    type: float
+    required: true
+    units: MW
+    description: >
+      The nameplate capacity of the generating unit in MW.
+
+      All values should be > 0.0.
+  commissioning_date:
+    type: date
+    required: false
+    description: >
+      The full date on which the generating unit is expected to begin operation.
+
+      Date format: %d/%m/%Y
+
+      If absent: set to first date of the modelling horizon (assume operational from start).
+  closure_year:
+    type: int
+    required: false
+    description: >
+      The integer year in which the generating unit is expected to be retired.
+
+      If absent: assume the unit is not retired during the modelling horizon.
+  minimum_load:
+    type: float
+    required: false
+    units: MW
+    description: >
+      The minimum stable operational level of the generating unit in MW.
+
+      All values should be >= 0.0 if present.
+
+      If absent: assume no minimum operational load for the generating unit.

--- a/src/ispypsa/validation/schemas/generators_existing_planned.yaml
+++ b/src/ispypsa/validation/schemas/generators_existing_planned.yaml
@@ -55,7 +55,8 @@ columns:
   fuel_type:
     type: string
     required: true
-    allowed_values: ["Black Coal", "Brown Coal", "Liquid Fuel", "Gas", "Water", "Solar", "Wind", "Biomass"]
+    allowed_values_from:
+      - costs_fuel_prices: fuel_type
     description: >
       The name of the type of fuel used by the generating unit.
 

--- a/src/ispypsa/validation/schemas/generators_existing_planned.yaml
+++ b/src/ispypsa/validation/schemas/generators_existing_planned.yaml
@@ -2,8 +2,6 @@ table: generators_existing_planned
 required: false
 unique:
   - [name]
-optional_sets:
-  - [fuel_price_node, vom, heat_rate] # All required if dynamic marginal costs are to be calculated
 description: >
   Existing and planned-build generator characteristic data by generating unit.
 
@@ -11,10 +9,9 @@ description: >
   committed, anticipated and additional policy-supported) generators, with each row
   containing information to represent a single generating unit.
 
-  Source IASR tables:
+  Source tables:
     - `existing_committed_anticipated_additional_generator_summary`
     - `renewable_energy_zones`
-    - `fixed_opex_existing_committed_anticipated_additional_generators`
     - `variable_opex_existing_committed_anticipated_additional_generators`
     - `heat_rates_existing_committed_anticipated_additional_generators`
     - `maximum_capacity_existing_committed_anticipated_additional_generators`
@@ -22,8 +19,8 @@ description: >
     - `gpg_min_stable_level_existing_generators`
     - `coal_minimum_stable_level`
 
-  If absent: a greenfield model will be run - no existing generators will be considered
-  and built in the model.
+  If absent:
+  A greenfield model will be run — no existing generators will be modelled.
 columns:
   name:
     type: string
@@ -53,94 +50,79 @@ columns:
     type: string
     required: true
     allowed_values_from:
-      table: network_geography
-      column: geo_id
+      - network_geography: geo_id
     description: The geography identifier to which the generating unit is connected.
   fuel_type:
     type: string
     required: true
+    allowed_values: ["Black Coal", "Brown Coal", "Liquid Fuel", "Gas", "Water", "Solar", "Wind", "Biomass"]
     description: >
       The name of the type of fuel used by the generating unit.
 
       This column is used to define the `carrier` for the generating unit in the
       PyPSA model, and to map to fuel prices.
-  fuel_price_node:
+  fuel_price_mapping:
     type: string
-    required: false
+    required: true
+    allowed_values_from:
+      - costs_fuel_prices: fuel_price_mapping
     description: >
       The power station name or other identifier used to map fuel prices to the generator.
 
       Note: for all power stations except for Kogan Gas, this should exactly match
       the `power_station` column.
-
-      If absent: assume no dynamic marginal price is calculated for this model run.
-  fom:
-    type: float
-    required: false
-    units: $/MW/year
-    description: >
-      Fixed operation and maintenance cost per unit of capacity per year.
-
-      All values should be in AUD and >= $0.0 if present. In the 2026 ISP for
-      existing and planned generating units, this value would be used to determine
-      retirement schedules based on a revenue sufficiency criterion; this is not
-      yet implemented here.
-
-      If absent: no change.
-  vom:
-    type: float
-    required: false
-    units: $/MWh
-    description: >
-      Variable operation and maintenance cost per unit of energy produced, not including fuel cost.
-
-      All values should be in AUD and >= $0.0 if present. These values are used to
-      calculate the short-run marginal cost of generation for a given unit.
-
-      If absent: assume no dynamic marginal price is calculated for this model run.
-  heat_rate:
-    type: float
-    required: false
-    units: GJ/MWh
-    description: >
-      The heat rate of the generating unit, used to calculate the fuel cost per unit
-      of energy produced.
-
-      All values should be >= 0.0 if present. These values are used to
-      calculate the short-run marginal cost of generation for a given unit.
-
-      If absent: assume no dynamic marginal price is calculated for this model run.
   capacity:
     type: float
     required: true
     units: MW
+    gt: 0.0
+    description: The nameplate capacity of the generating unit in MW.
+  vom:
+    type: float
+    required: true
+    units: $/MWh
+    gte: 0.0
     description: >
-      The nameplate capacity of the generating unit in MW.
+      Variable operation and maintenance cost per unit of energy produced, not including fuel cost.
 
-      All values should be > 0.0.
+      These values are used to calculate the short-run marginal cost of generation
+      for a given unit.
+  heat_rate:
+    type: float
+    required: true
+    units: GJ/MWh
+    gte: 0.0
+    description: >
+      The heat rate of the generating unit, used to calculate the fuel cost per unit
+      of energy produced.
+
+      These values are used to calculate the short-run marginal cost of generation
+      for a given unit.
   commissioning_date:
     type: date
     required: false
+    format: "%d/%m/%Y"
     description: >
       The full date on which the generating unit is expected to begin operation.
 
-      Date format: %d/%m/%Y
-
-      If absent: set to first date of the modelling horizon (assume operational from start).
+      If absent:
+      The unit is assumed operational from the start of the modelling horizon.
   closure_year:
     type: int
     required: false
     description: >
       The integer year in which the generating unit is expected to be retired.
 
-      If absent: assume the unit is not retired during the modelling horizon.
+      If absent:
+      The unit is not retired during the modelling horizon.
   minimum_load:
     type: float
     required: false
     units: MW
+    gte: 0.0
+    nan_fill: 0.0
     description: >
       The minimum stable operational level of the generating unit in MW.
 
-      All values should be >= 0.0 if present.
-
-      If absent: assume no minimum operational load for the generating unit.
+      If absent:
+      No minimum operational load is applied to this generating unit.

--- a/src/ispypsa/validation/schemas/generators_new_entrant.yaml
+++ b/src/ispypsa/validation/schemas/generators_new_entrant.yaml
@@ -1,0 +1,154 @@
+table: generators_new_entrant
+required: false
+unique:
+  - [name]
+optional_sets:
+  - [fuel_price_node, vom, heat_rate] # All required if dynamic marginal costs are to be calculated
+description: >
+  New entrant generator characteristic data by technology type, resource type and location.
+
+  Summary data for all new entrant generation units, with each row containing
+  information about a single generating unit. This table does not include
+  storage technologies.
+
+  Source IASR tables:
+    - `new_entrants_summary`
+    - `renewable_energy_zones`
+    - `fixed_opex_new_entrants`
+    - `variable_opex_new_entrants`
+    - `heat_rates_new_entrants`
+    - `lead_time_and_project_life`
+    - `gpg_min_stable_level_new_entrants`
+    - `locational_cost_factors`
+    - `technology_cost_breakdown_ratios`
+
+  If absent: only existing (and planned) generation will be modelled.
+columns:
+  name:
+    type: string
+    required: true
+    description: >
+      Unique name for each generating unit to be modelled.
+  technology:
+    type: string
+    required: true
+    description: >
+      The full proper name of the technology type as given in the IASR workbook.
+
+      Values in this column are used as 'canon' technology types across the model -
+      i.e. used to correct typos or map different spellings to a single canonical value.
+  resource_type:
+    type: string
+    required: true
+    description: >
+      Standard string value specifying the ISP-defined resource type (e.g. offshore wind - floating).
+  geo_id:
+    type: string
+    required: true
+    allowed_values_from:
+      table: network_geography
+      column: geo_id
+    description: >
+      Locational identifier - either subregion or REZ, depending on where the generator
+      connection is defined.
+  fuel_type:
+    type: string
+    required: true
+    description: >
+      The name of the type of fuel used by the generating unit.
+
+      This column is used to define the `carrier` for the generating unit in the
+      PyPSA model, and to map to fuel prices.
+  fuel_price_node:
+    type: string
+    required: false
+    description: >
+      The string that maps to fuel costs for this generator.
+
+      For new entrant generators, fuel prices (e.g. for OCGT) are given at the regional
+      node level such as "QLD new OCGT".
+
+      If absent: assume no dynamic marginal price is calculated for this model run.
+  fom:
+    type: float
+    required: false
+    units: $/MW/year
+    description: >
+      Fixed operation and maintenance cost per unit of capacity per year.
+
+      All values should be in AUD and >= $0.0 if present. Used to help determine
+      early retirement schedules in the ISP modelling (not currently implemented).
+
+      If absent: no change.
+  vom:
+    type: float
+    required: false
+    units: $/MWh
+    description: >
+      Variable operation and maintenance cost per unit of energy produced, not including fuel cost.
+
+      All values should be in AUD and >= $0.0 if present. These values are used to
+      calculate the short-run marginal cost of generation for a given unit.
+
+      If absent: assume no dynamic marginal price is calculated for this model run.
+  lcf_build:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Locational cost factor - applies to build and connection costs to
+      scale costs according to location.
+
+      All values should be >= 0.0 if present.
+
+      If absent (or empty): assume costs are as given with no locational scaling applied (100%).
+  lcf_om:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Locational cost factor - applies to fixed and variable operation and maintenance
+      costs to scale costs according to location.
+
+      All values should be >= 0.0 if present.
+
+      If absent (or empty): assume costs are as given with no locational scaling applied (100%).
+  lifetime_technical:
+    type: float
+    required: true
+    units: years
+    description: >
+      Technical lifetime of a generator in years. Should be > 0.0.
+
+      Used to specify whether the unit is operational during a given investment period;
+      starts from the PyPSA attribute build_year (added in translator).
+  lifetime_economic:
+    type: float
+    required: false
+    units: years
+    description: >
+      Economic lifetime of a generator in years. Should be > 0.0.
+
+      Used to calculate annuitised capital cost over the economic lifetime of the unit.
+
+      If absent: `lifetime_technical` is used.
+  heat_rate:
+    type: float
+    required: false
+    units: GJ/MWh
+    description: >
+      The heat rate of the generating unit, describing the efficiency of thermal generators.
+
+      All values should be >= 0.0 if present. These values are used to
+      calculate the short-run marginal cost of generation for a given unit.
+
+      If absent: assume no dynamic marginal price is calculated for this model run.
+  minimum_stable_level:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Minimum stable operating level as a percentage of maximum capacity.
+      Should be between 0.0 and 100.0.
+
+      If absent: no minimum operating level constraint.

--- a/src/ispypsa/validation/schemas/generators_new_entrant.yaml
+++ b/src/ispypsa/validation/schemas/generators_new_entrant.yaml
@@ -41,7 +41,8 @@ columns:
   resource_type:
     type: string
     required: false
-    allowed_values: ["solar", "solar_thermal", "wind_medium", "wind_high", "wind_offshore_fixed", "wind_offshore_floating"]
+    allowed_values_from:
+      - resource_limits: resource_type
     description: >
       Standard string value specifying the ISP-defined resource type of variable
       renewable energy (VRE) generating units only.
@@ -61,7 +62,8 @@ columns:
   fuel_type:
     type: string
     required: true
-    allowed_values: ["Black Coal", "Brown Coal", "Liquid Fuel", "Gas", "Water", "Solar", "Wind", "Biomass"]
+    allowed_values_from:
+      - costs_fuel_prices: fuel_type
     description: >
       The name of the type of fuel used by the generating unit.
 

--- a/src/ispypsa/validation/schemas/generators_new_entrant.yaml
+++ b/src/ispypsa/validation/schemas/generators_new_entrant.yaml
@@ -2,8 +2,6 @@ table: generators_new_entrant
 required: false
 unique:
   - [name]
-optional_sets:
-  - [fuel_price_node, vom, heat_rate] # All required if dynamic marginal costs are to be calculated
 description: >
   New entrant generator characteristic data by technology type, resource type and location.
 
@@ -11,7 +9,7 @@ description: >
   information about a single generating unit. This table does not include
   storage technologies.
 
-  Source IASR tables:
+  Source tables:
     - `new_entrants_summary`
     - `renewable_energy_zones`
     - `fixed_opex_new_entrants`
@@ -22,103 +20,113 @@ description: >
     - `locational_cost_factors`
     - `technology_cost_breakdown_ratios`
 
-  If absent: only existing (and planned) generation will be modelled.
+  If absent:
+  Only existing (and planned) generation will be modelled.
 columns:
   name:
     type: string
     required: true
-    description: >
-      Unique name for each generating unit to be modelled.
+    description: Unique name for each generating unit to be modelled.
   technology:
     type: string
     required: true
+    allowed_values_from:
+      - costs_new_entrant_build: technology
     description: >
       The full proper name of the technology type as given in the IASR workbook.
 
       Values in this column are used as 'canon' technology types across the model -
       i.e. used to correct typos or map different spellings to a single canonical value.
+      Any technology present in this table must also have a build cost defined.
   resource_type:
     type: string
-    required: true
+    required: false
+    allowed_values: ["solar", "solar_thermal", "wind_medium", "wind_high", "wind_offshore_fixed", "wind_offshore_floating"]
     description: >
-      Standard string value specifying the ISP-defined resource type (e.g. offshore wind - floating).
+      Standard string value specifying the ISP-defined resource type of variable
+      renewable energy (VRE) generating units only.
+
+      Used to apply VRE build limit constraints by resource type.
+
+      If absent (or empty):
+      No VRE build limit constraint is applied to the corresponding generating unit.
   geo_id:
     type: string
     required: true
     allowed_values_from:
-      table: network_geography
-      column: geo_id
+      - network_geography: geo_id
     description: >
       Locational identifier - either subregion or REZ, depending on where the generator
       connection is defined.
   fuel_type:
     type: string
     required: true
+    allowed_values: ["Black Coal", "Brown Coal", "Liquid Fuel", "Gas", "Water", "Solar", "Wind", "Biomass"]
     description: >
       The name of the type of fuel used by the generating unit.
 
       This column is used to define the `carrier` for the generating unit in the
       PyPSA model, and to map to fuel prices.
-  fuel_price_node:
+  fuel_price_mapping:
     type: string
-    required: false
+    required: true
+    allowed_values_from:
+      - costs_fuel_prices: fuel_price_mapping
     description: >
       The string that maps to fuel costs for this generator.
 
       For new entrant generators, fuel prices (e.g. for OCGT) are given at the regional
       node level such as "QLD new OCGT".
-
-      If absent: assume no dynamic marginal price is calculated for this model run.
   fom:
     type: float
-    required: false
+    required: true
     units: $/MW/year
+    gte: 0.0
     description: >
       Fixed operation and maintenance cost per unit of capacity per year.
 
-      All values should be in AUD and >= $0.0 if present. Used to help determine
-      early retirement schedules in the ISP modelling (not currently implemented).
-
-      If absent: no change.
+      Used to calculate annuitised capital costs for new entrant generation units.
   vom:
     type: float
-    required: false
+    required: true
     units: $/MWh
+    gte: 0.0
     description: >
       Variable operation and maintenance cost per unit of energy produced, not including fuel cost.
 
-      All values should be in AUD and >= $0.0 if present. These values are used to
-      calculate the short-run marginal cost of generation for a given unit.
-
-      If absent: assume no dynamic marginal price is calculated for this model run.
+      These values are used to calculate the short-run marginal cost of generation
+      for a given unit.
   lcf_build:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    nan_fill: 100.0
     description: >
       Locational cost factor - applies to build and connection costs to
       scale costs according to location.
 
-      All values should be >= 0.0 if present.
-
-      If absent (or empty): assume costs are as given with no locational scaling applied (100%).
+      If absent (or empty):
+      Costs are as given with no locational scaling applied.
   lcf_om:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    nan_fill: 100.0
     description: >
       Locational cost factor - applies to fixed and variable operation and maintenance
       costs to scale costs according to location.
 
-      All values should be >= 0.0 if present.
-
-      If absent (or empty): assume costs are as given with no locational scaling applied (100%).
+      If absent (or empty):
+      Costs are as given with no locational scaling applied.
   lifetime_technical:
     type: float
     required: true
     units: years
+    gt: 0.0
     description: >
-      Technical lifetime of a generator in years. Should be > 0.0.
+      Technical lifetime of a generator in years.
 
       Used to specify whether the unit is operational during a given investment period;
       starts from the PyPSA attribute build_year (added in translator).
@@ -126,29 +134,33 @@ columns:
     type: float
     required: false
     units: years
+    gt: 0.0
     description: >
-      Economic lifetime of a generator in years. Should be > 0.0.
+      Economic lifetime of a generator in years.
 
       Used to calculate annuitised capital cost over the economic lifetime of the unit.
 
-      If absent: `lifetime_technical` is used.
+      If absent (or empty):
+      `lifetime_technical` values are used.
   heat_rate:
     type: float
-    required: false
+    required: true
     units: GJ/MWh
+    gte: 0.0
     description: >
       The heat rate of the generating unit, describing the efficiency of thermal generators.
 
-      All values should be >= 0.0 if present. These values are used to
-      calculate the short-run marginal cost of generation for a given unit.
-
-      If absent: assume no dynamic marginal price is calculated for this model run.
+      These values are used to calculate the short-run marginal cost of generation
+      for a given unit.
   minimum_stable_level:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
+    nan_fill: 0.0
     description: >
       Minimum stable operating level as a percentage of maximum capacity.
-      Should be between 0.0 and 100.0.
 
-      If absent: no minimum operating level constraint.
+      If absent:
+      No minimum operating level modelled.

--- a/src/ispypsa/validation/schemas/storage_existing_planned.yaml
+++ b/src/ispypsa/validation/schemas/storage_existing_planned.yaml
@@ -1,0 +1,141 @@
+table: storage_existing_planned
+required: false
+unique:
+  - [name]
+description: >
+  Existing and planned-build storage unit characteristics, including battery storage
+  and pumped hydro.
+
+  Each row represents a single storage unit. In ISP terminology, this includes
+  committed, anticipated and additional policy-supported storage.
+
+  Source tables:
+    - `existing_committed_anticipated_additional_generator_summary`
+    - `renewable_energy_zones`
+    - `maximum_capacity_existing_committed_anticipated_additional_generators`
+    - `fixed_opex_existing_committed_anticipated_additional_generators`
+    - `battery_properties`
+    - `pumped_hydro_existing_committed_anticipated_additional_properties`
+    - `expected_closure_years`
+
+  If absent: only new entrant storage will be modelled (greenfield model).
+columns:
+  name:
+    type: string
+    required: true
+    description: Unique identifier for the storage unit (e.g. DUID or full name).
+  power_station:
+    type: string
+    required: true
+    description: >
+      Power station name grouping storage units together.
+
+      Used to group units in results and charts. For PHES, this name maps to
+      PHES properties. May match `name` for single-unit power stations.
+  technology:
+    type: string
+    required: true
+    description: >
+      Technology type as given in the IASR workbook.
+
+      Used as the canonical technology type across the model to standardise
+      spellings and group results by technology.
+  geo_id:
+    type: string
+    required: true
+    allowed_values_from:
+      table: network_geography
+      column: geo_id
+    description: Network geography identifier where the storage unit is connected.
+  fuel_type:
+    type: string
+    required: true
+    description: >
+      Fuel type used by the storage unit.
+
+      Defines the `carrier` in PyPSA. Maintained for consistency and grouping results,
+      though less relevant for storage than generators.
+  capacity:
+    type: float
+    required: true
+    units: MW
+    description: >
+      Nameplate capacity (maximum power rating) in MW. Must be > 0.0.
+  storage_capacity:
+    type: float
+    required: true
+    units: MWh
+    description: >
+      Energy capacity in MWh. Must be > 0.0.
+  fom:
+    type: float
+    required: false
+    units: $/MW/year
+    description: >
+      Fixed operation and maintenance cost per MW per year (AUD). Must be >= $0.0
+      or blank (assumed $0.0).
+
+      In the 2026 ISP, this determines retirement schedules via revenue sufficiency;
+      not yet implemented here.
+
+      If absent: no change.
+  efficiency_charge:
+    type: float
+    required: true
+    units: '%'
+    description: >
+      Charging efficiency (%). Must be between 0.0 and 100.0.
+
+      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
+      assuming symmetric charge/discharge.
+  efficiency_discharge:
+    type: float
+    required: true
+    units: '%'
+    description: >
+      Discharging efficiency (%). Must be between 0.0 and 100.0.
+
+      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
+      assuming symmetric charge/discharge.
+  soc_max:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Maximum allowed state of charge (%). Must be between 0.0 and 100.0,
+      and >= soc_min if both present.
+
+      If absent: defaults to 100.
+  soc_min:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Minimum allowed state of charge (%). Must be between 0.0 and 100.0,
+      and <= soc_max if both present.
+
+      If absent: defaults to 0.
+  degradation_annual:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Annual capacity degradation rate (%). Must be between 0.0 and 100.0.
+
+      Not currently applied in the model.
+
+      If absent: no degradation modelled.
+  commissioning_date:
+    type: date
+    required: false
+    description: >
+      Date when the storage unit begins operation. Format: %d/%m/%Y
+
+      If absent: operational from start of modelling horizon.
+  closure_year:
+    type: int
+    required: false
+    description: >
+      Financial year when the storage unit retires.
+
+      If absent: no retirement during modelling horizon.

--- a/src/ispypsa/validation/schemas/storage_existing_planned.yaml
+++ b/src/ispypsa/validation/schemas/storage_existing_planned.yaml
@@ -146,7 +146,7 @@ columns:
     type: int
     required: false
     description: >
-      Financial year when the storage unit retires.
+      Year when the storage unit retires.
 
       If absent:
       The unit is not retired during the modelling horizon.

--- a/src/ispypsa/validation/schemas/storage_existing_planned.yaml
+++ b/src/ispypsa/validation/schemas/storage_existing_planned.yaml
@@ -2,6 +2,11 @@ table: storage_existing_planned
 required: false
 unique:
   - [name]
+custom_validation:
+  - name: soc_min_lte_soc_max
+    description: >
+      When both soc_min and soc_max are present for a row, soc_min must be less than
+      or equal to soc_max.
 description: >
   Existing and planned-build storage unit characteristics, including battery storage
   and pumped hydro.
@@ -13,12 +18,12 @@ description: >
     - `existing_committed_anticipated_additional_generator_summary`
     - `renewable_energy_zones`
     - `maximum_capacity_existing_committed_anticipated_additional_generators`
-    - `fixed_opex_existing_committed_anticipated_additional_generators`
     - `battery_properties`
     - `pumped_hydro_existing_committed_anticipated_additional_properties`
     - `expected_closure_years`
 
-  If absent: only new entrant storage will be modelled (greenfield model).
+  If absent:
+  Only new entrant storage will be modelled (greenfield storage model).
 columns:
   name:
     type: string
@@ -44,98 +49,104 @@ columns:
     type: string
     required: true
     allowed_values_from:
-      table: network_geography
-      column: geo_id
+      - network_geography: geo_id
     description: Network geography identifier where the storage unit is connected.
   fuel_type:
     type: string
     required: true
+    allowed_values: ["Water", "Battery"]
     description: >
       Fuel type used by the storage unit.
 
-      Defines the `carrier` in PyPSA. Maintained for consistency and grouping results,
-      though less relevant for storage than generators.
+      Defines the `carrier` in PyPSA. Maintained for consistency and grouping results.
   capacity:
     type: float
     required: true
     units: MW
-    description: >
-      Nameplate capacity (maximum power rating) in MW. Must be > 0.0.
+    gt: 0.0
+    description: Nameplate capacity (maximum power rating) in MW.
   storage_capacity:
     type: float
     required: true
     units: MWh
-    description: >
-      Energy capacity in MWh. Must be > 0.0.
-  fom:
-    type: float
-    required: false
-    units: $/MW/year
-    description: >
-      Fixed operation and maintenance cost per MW per year (AUD). Must be >= $0.0
-      or blank (assumed $0.0).
-
-      In the 2026 ISP, this determines retirement schedules via revenue sufficiency;
-      not yet implemented here.
-
-      If absent: no change.
+    gt: 0.0
+    description: Energy capacity in MWh.
   efficiency_charge:
     type: float
     required: true
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
-      Charging efficiency (%). Must be between 0.0 and 100.0.
+      Charging efficiency (%).
 
-      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
-      assuming symmetric charge/discharge.
+      Source notes:
+      For PHES with only round-trip efficiency given in IASR workbook tables, this
+      is calculated as round_trip**(1/2) assuming symmetric charge/discharge.
   efficiency_discharge:
     type: float
     required: true
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
-      Discharging efficiency (%). Must be between 0.0 and 100.0.
+      Discharging efficiency (%).
 
-      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
-      assuming symmetric charge/discharge.
+      Source notes:
+      For PHES with only round-trip efficiency given in IASR workbook tables, this
+      is calculated as round_trip**(1/2) assuming symmetric charge/discharge.
   soc_max:
+    # note: soc constraints not yet implemented.
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
+    nan_fill: 100.0
     description: >
-      Maximum allowed state of charge (%). Must be between 0.0 and 100.0,
-      and >= soc_min if both present.
+      Maximum allowed state of charge (%).
 
-      If absent: defaults to 100.
+      If absent:
+      No maximum state of charge constraint applies to this unit.
   soc_min:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
+    nan_fill: 0.0
     description: >
-      Minimum allowed state of charge (%). Must be between 0.0 and 100.0,
-      and <= soc_max if both present.
+      Minimum allowed state of charge (%).
 
-      If absent: defaults to 0.
+      If absent:
+      No minimum state of charge constraint applies to this unit.
   degradation_annual:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
-      Annual capacity degradation rate (%). Must be between 0.0 and 100.0.
+      Annual capacity degradation rate (%).
 
       Not currently applied in the model.
 
-      If absent: no degradation modelled.
+      If absent:
+      No degradation modelled.
   commissioning_date:
     type: date
     required: false
+    format: "%d/%m/%Y"
     description: >
-      Date when the storage unit begins operation. Format: %d/%m/%Y
+      Date when the storage unit begins operation.
 
-      If absent: operational from start of modelling horizon.
+      If absent:
+      The unit is assumed operational from start of modelling horizon.
   closure_year:
     type: int
     required: false
     description: >
       Financial year when the storage unit retires.
 
-      If absent: no retirement during modelling horizon.
+      If absent:
+      The unit is not retired during the modelling horizon.

--- a/src/ispypsa/validation/schemas/storage_new_entrant.yaml
+++ b/src/ispypsa/validation/schemas/storage_new_entrant.yaml
@@ -1,0 +1,171 @@
+table: storage_new_entrant
+required: false
+unique:
+  - [name]
+description: >
+  New entrant storage unit characteristics, including battery storage and pumped hydro.
+
+  Each row represents a single new entrant storage technology option.
+
+  Source tables:
+    - `new_entrants_summary`
+    - `renewable_energy_zones`
+    - `maximum_capacity_new_entrants`
+    - `fixed_opex_new_entrants`
+    - `battery_properties`
+    - `pumped_hydro_new_entrant_properties`
+    - `gpg_min_stable_level_new_entrants`
+    - `lead_time_and_project_life`
+    - `locational_cost_factors`
+    - `locational_cost_pumped_hydro_factors`
+    - `technology_cost_breakdown_ratios`
+
+  If absent: only existing or planned storage will be modelled.
+columns:
+  name:
+    type: string
+    required: true
+    description: Unique identifier for the storage unit (e.g. IASR ID or full name).
+  power_station:
+    type: string
+    required: false
+    description: >
+      Power station name grouping storage units together.
+
+      For new entrant storage units, this is always the same as the `name` field
+      (i.e, no grouping is performed). Keeping for consistency with existing storage tables.
+  technology:
+    type: string
+    required: true
+    description: >
+      Technology type as given in the IASR workbook.
+
+      Used as the canonical technology type across the model to standardise
+      spellings and group results by technology.
+  geo_id:
+    type: string
+    required: true
+    allowed_values_from:
+      table: network_geography
+      column: geo_id
+    description: Network geography identifier where the storage unit can be built.
+  fuel_type:
+    type: string
+    required: true
+    description: >
+      Fuel type used by the storage unit.
+
+      Defines the `carrier` in PyPSA. Maintained for consistency though less
+      relevant for storage than generators.
+  storage_hours:
+    type: float
+    required: true
+    units: h
+    description: >
+      Maximum storage duration in hours. Should be > 0.0.
+  fom:
+    type: float
+    required: false
+    units: $/MW/year
+    description: >
+      Fixed operation and maintenance cost per MW per year (AUD). Should be >= $0.0
+      or blank (assumed $0.0).
+
+      Used to calculate annuitised capital costs for new entrant storage units.
+  efficiency_charge:
+    type: float
+    required: true
+    units: '%'
+    description: >
+      Charging efficiency (%). Should be between 0.0 and 100.0.
+
+      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
+      assuming symmetric charge/discharge.
+  efficiency_discharge:
+    type: float
+    required: true
+    units: '%'
+    description: >
+      Discharging efficiency (%). Should be between 0.0 and 100.0.
+
+      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
+      assuming symmetric charge/discharge.
+  soc_max:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Maximum allowed state of charge (%). Should be between 0.0 and 100.0,
+      and >= soc_min if both present.
+
+      If absent: defaults to 100.
+  soc_min:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Minimum allowed state of charge (%). Should be between 0.0 and 100.0,
+      and <= soc_max if both present.
+
+      If absent: defaults to 0.
+  minimum_stable_level:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Minimum stable operating level as a percentage of maximum capacity.
+      Should be between 0.0 and 100.0. Assume 0.0 if blank.
+
+      Only applies to PHES units according to IASR workbook.
+
+      If absent: no minimum operating level constraint.
+  lcf_build:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Locational cost factor - applies to build and connection costs to
+      scale costs according to location.
+
+      All values should be >= 0.0 if present.
+
+      If absent: assume costs are as given with no locational scaling applied (100%).
+  lcf_om:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Locational cost factor - applies to fixed and variable operation and maintenance
+      costs to scale costs according to location.
+
+      All values should be >= 0.0 if present.
+
+      If absent: assume costs are as given with no locational scaling applied (100%).
+  lifetime_technical:
+    type: float
+    required: true
+    units: years
+    description: >
+      Technical lifetime in years. Should be > 0.0.
+
+      Determines whether the unit is operational during a given investment period.
+  lifetime_economic:
+    type: float
+    required: false
+    units: years
+    description: >
+      Economic lifetime in years. Should be > 0.0.
+
+      Used to calculate annuitised capital cost.
+
+      If absent: `lifetime_technical` is used.
+  degradation_annual:
+    type: float
+    required: false
+    units: '%'
+    description: >
+      Annual capacity degradation rate (%). Should be between 0.0 and 100.0.
+
+      Not currently applied in the model.
+
+      If absent: no degradation modelled.

--- a/src/ispypsa/validation/schemas/storage_new_entrant.yaml
+++ b/src/ispypsa/validation/schemas/storage_new_entrant.yaml
@@ -2,6 +2,11 @@ table: storage_new_entrant
 required: false
 unique:
   - [name]
+custom_validation:
+  - name: soc_min_lte_soc_max
+    description: >
+      When both soc_min and soc_max are present for a row, soc_min must be less than
+      or equal to soc_max.
 description: >
   New entrant storage unit characteristics, including battery storage and pumped hydro.
 
@@ -20,7 +25,8 @@ description: >
     - `locational_cost_pumped_hydro_factors`
     - `technology_cost_breakdown_ratios`
 
-  If absent: only existing or planned storage will be modelled.
+  If absent:
+  Only existing or planned storage will be modelled.
 columns:
   name:
     type: string
@@ -28,7 +34,7 @@ columns:
     description: Unique identifier for the storage unit (e.g. IASR ID or full name).
   power_station:
     type: string
-    required: false
+    required: true
     description: >
       Power station name grouping storage units together.
 
@@ -37,135 +43,161 @@ columns:
   technology:
     type: string
     required: true
+    allowed_values_from:
+      - costs_new_entrant_build: technology
     description: >
       Technology type as given in the IASR workbook.
 
       Used as the canonical technology type across the model to standardise
-      spellings and group results by technology.
+      spellings and group results by technology. Any technology present in this
+      table must have a build cost defined.
   geo_id:
     type: string
     required: true
     allowed_values_from:
-      table: network_geography
-      column: geo_id
+      - network_geography: geo_id
     description: Network geography identifier where the storage unit can be built.
   fuel_type:
     type: string
     required: true
+    allowed_values: ["Water", "Battery"]
     description: >
       Fuel type used by the storage unit.
 
-      Defines the `carrier` in PyPSA. Maintained for consistency though less
-      relevant for storage than generators.
+      Defines the `carrier` in PyPSA. Maintained for consistency and grouping results.
   storage_hours:
     type: float
     required: true
     units: h
-    description: >
-      Maximum storage duration in hours. Should be > 0.0.
+    gt: 0.0
+    description: Maximum storage duration in hours.
   fom:
     type: float
-    required: false
+    required: true
     units: $/MW/year
+    gte: 0.0
     description: >
-      Fixed operation and maintenance cost per MW per year (AUD). Should be >= $0.0
-      or blank (assumed $0.0).
+      Fixed operation and maintenance cost per MW per year.
 
       Used to calculate annuitised capital costs for new entrant storage units.
   efficiency_charge:
     type: float
     required: true
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
-      Charging efficiency (%). Should be between 0.0 and 100.0.
+      Charging efficiency (%).
 
-      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
-      assuming symmetric charge/discharge.
+      Source notes:
+      For PHES with only round-trip efficiency given in IASR workbook tables, this
+      is calculated as round_trip**(1/2) assuming symmetric charge/discharge.
   efficiency_discharge:
     type: float
     required: true
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
-      Discharging efficiency (%). Should be between 0.0 and 100.0.
+      Discharging efficiency (%).
 
-      For PHES with only round-trip efficiency, calculated as round_trip**(1/2)
-      assuming symmetric charge/discharge.
+      Source notes:
+      For PHES with only round-trip efficiency given in IASR workbook tables, this
+      is calculated as round_trip**(1/2) assuming symmetric charge/discharge.
   soc_max:
+    # note: soc constraints not yet implemented.
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
+    nan_fill: 100.0
     description: >
-      Maximum allowed state of charge (%). Should be between 0.0 and 100.0,
-      and >= soc_min if both present.
+      Maximum allowed state of charge (%).
 
-      If absent: defaults to 100.
+      If absent:
+      No maximum state of charge constraint applies to this unit.
   soc_min:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
+    nan_fill: 0.0
     description: >
-      Minimum allowed state of charge (%). Should be between 0.0 and 100.0,
-      and <= soc_max if both present.
+      Minimum allowed state of charge (%).
 
-      If absent: defaults to 0.
+      If absent:
+      No minimum state of charge constraint applies to this unit.
   minimum_stable_level:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
+    nan_fill: 0.0
     description: >
       Minimum stable operating level as a percentage of maximum capacity.
-      Should be between 0.0 and 100.0. Assume 0.0 if blank.
 
-      Only applies to PHES units according to IASR workbook.
+      Only applies to PHES units per the IASR workbook.
 
-      If absent: no minimum operating level constraint.
+      If absent:
+      No minimum operating level constraint.
   lcf_build:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    nan_fill: 100.0
     description: >
       Locational cost factor - applies to build and connection costs to
       scale costs according to location.
 
-      All values should be >= 0.0 if present.
-
-      If absent: assume costs are as given with no locational scaling applied (100%).
+      If absent:
+      Costs are as given with no locational scaling applied.
   lcf_om:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    nan_fill: 100.0
     description: >
       Locational cost factor - applies to fixed and variable operation and maintenance
       costs to scale costs according to location.
 
-      All values should be >= 0.0 if present.
-
-      If absent: assume costs are as given with no locational scaling applied (100%).
+      If absent:
+      Costs are as given with no locational scaling applied.
   lifetime_technical:
     type: float
     required: true
     units: years
+    gt: 0.0
     description: >
-      Technical lifetime in years. Should be > 0.0.
+      Technical lifetime in years.
 
       Determines whether the unit is operational during a given investment period.
   lifetime_economic:
     type: float
     required: false
     units: years
+    gt: 0.0
     description: >
-      Economic lifetime in years. Should be > 0.0.
+      Economic lifetime in years.
 
       Used to calculate annuitised capital cost.
 
-      If absent: `lifetime_technical` is used.
+      If absent:
+      `lifetime_technical` is used.
   degradation_annual:
     type: float
     required: false
     units: '%'
+    gte: 0.0
+    lte: 100.0
     description: >
-      Annual capacity degradation rate (%). Should be between 0.0 and 100.0.
+      Annual capacity degradation rate (%).
 
       Not currently applied in the model.
 
-      If absent: no degradation modelled.
+      If absent:
+      No degradation modelled.


### PR DESCRIPTION
Adds YAML validation schemas for generation and storage input tables to the initial set of ISPyPSA input table schemas.

Schemas added:
* `generators_existing_planned.yaml` - Existing and planned generator characteristics
* `generators_new_entrant.yaml` - New entrant generator technology options
* `storage_existing_planned.yaml` - Existing and planned storage unit characteristics
* `storage_new_entrant.yaml` - New entrant storage technology options (battery, PHES)
* `costs_connection.yaml` - Connection cost data
* `costs_fuel_prices.yaml` - Fuel price projections
* `costs_new_entrant_build.yaml` - Build cost projections for new entrants
* `emissions_reduction.yaml` - Emissions reduction targets/constraints

Still to be added: policy table schemas. 

Schemas follow structure as outlined in #85 and mostly follow the draft table structures given in the [alternative templater review](https://github.com/Open-ISP/project-planning/pull/4/changes), with tweaks to match the 2026 (v7.5) IASR workbook data. 