### PR TITLE
Template new non vre connection costs

### DIFF
--- a/src/ispypsa/templater/connection_and_build_costs.py
+++ b/src/ispypsa/templater/connection_and_build_costs.py
@@ -76,7 +76,7 @@ def _template_connection_costs(
     Returns:
         One row per (geo_id, technology, year). connection_cost and
         system_strength_cost are in $/MW; system_strength_cost is 0.0 for
-        non-IBR technologies and offshore wind.
+        non-IBR technologies and solar thermal.
 
     I/O Example:
         Inputs (abbreviated; regional_granularity="nem_regions"):

--- a/src/ispypsa/templater/connection_and_build_costs.py
+++ b/src/ispypsa/templater/connection_and_build_costs.py
@@ -19,113 +19,146 @@ _VRE_COLUMN_RENAMES = {
     "REZ ID": "geo_id",
     "Connection capacity (MVA)": "connection_capacity",
 }
+_NON_VRE_COLUMN_RENAMES = {
+    "Region": "region_id",
+    "Generator Type": "technology",
+    "Connection capacity (MVA)": "connection_capacity",
+}
 
+# NOTE: the VRE / non-VRE split below is approximate, not strict. The IASR
+# "connection_cost_forecast_other" (non-VRE) table actually includes "distributed
+# solar", so "non-VRE" really means "everything templated outside the wind/solar
+# REZ-connection path". This is a known wart — revisit how distributed resources
+# are handled once more of the templater (and schema validation) is in place.
 _VRE_TECHNOLOGY_STRINGS = ["solar", "wind"]
 _IBR_TECHNOLOGY_STRINGS = _VRE_TECHNOLOGY_STRINGS + ["battery", "batteries"]
+_NON_VRE_EXCLUDED_TECHNOLOGIES = ["Alkaline Electrolyser", "BOTN - Cethana"]
 
 
 def _template_connection_costs(
-    connection_cost_forecast_vre: pd.DataFrame,
-    connection_costs_for_vre: pd.DataFrame,
-    system_strength_cost_table: pd.DataFrame,
+    iasr_tables: dict[str, pd.DataFrame],
     scenario: str,
+    regional_granularity: str,
     generators_new_entrant: pd.DataFrame,
+    storage_new_entrant: pd.DataFrame,
+    sub_regional_geography: pd.DataFrame,
 ) -> pd.DataFrame:
     """Combines VRE and non-VRE connection costs with system strength costs.
 
     Produces a long-format table with columns (geo_id, technology, year,
-    connection_cost, system_strength_cost) from three IASR source tables.
-    VRE (wind/solar) costs are templated and system strength costs are merged
-    in to return a single ISPyPSA format table: ``costs_connection``.
-
-    Note: non-VRE connection costs will be added in a subsequent PR.
+    connection_cost, system_strength_cost). VRE (wind/solar) costs are templated
+    per-REZ; non-VRE costs are templated per-region and expanded to geo_id level
+    based on ``regional_granularity``. System strength costs ($/MW) are merged in
+    for all IBR technologies (wind, solar, battery).
 
     Args:
-        connection_cost_forecast_vre: IASR ``connection_cost_forecast_wind_and_solar``
-            table. Columns: 'REZ ID', 'Scenario', one column per financial year.
-        connection_costs_for_vre: IASR ``connection_costs_for_wind_and_solar`` table.
-            Columns: 'REZ ID', 'Connection capacity (MVA)'.
-        system_strength_cost_table: IASR ``efficient_level_of_system_strength_cost``
-            table. Single row with one column per financial year (cost in $/kW).
+        iasr_tables: dict containing the following keys:
+            ``connection_cost_forecast_wind_and_solar``: columns REZ ID, Scenario,
+                one column per financial year (total connection cost in $).
+            ``connection_costs_for_wind_and_solar``: columns REZ ID, Connection
+                capacity (MVA).
+            ``connection_cost_forecast_other``: columns Generator Type, Region,
+                Scenario, one column per financial year (total connection cost in $).
+            ``connection_capacity_non_vre``: columns Region, Generator Type,
+                Connection capacity (MVA). Manually extracted — see
+                ``manually_extracted_template_tables/``.
+            ``efficient_level_of_system_strength_cost``: single row with one column
+                per financial year (IBR remediation cost in $/kW).
         scenario: ISP scenario name, e.g. "Step Change".
-        generators_new_entrant: templated new entrant generators table.
-            Columns used: 'geo_id' and 'technology'.
+        regional_granularity: "sub_regions", "nem_regions", or "single_region".
+        generators_new_entrant: templated new entrant generators table;
+            columns used: 'geo_id' and 'technology'.
+        storage_new_entrant: templated new entrant storage table;
+            columns used: 'geo_id' and 'technology'.
+        sub_regional_geography: templated network geography table;
+            columns used: 'geo_id', 'geo_type', 'region_id'.
 
     Returns:
         One row per (geo_id, technology, year). connection_cost and
-        system_strength_cost are in $/MW; either may be NaN where no cost
-        applies for that combination.
+        system_strength_cost are in $/MW; system_strength_cost is 0.0 for
+        non-IBR technologies and offshore wind.
 
     I/O Example:
-        Inputs (abbreviated):
+        Inputs (abbreviated; regional_granularity="nem_regions"):
 
-            connection_cost_forecast_vre:
-                REZ ID  REZ names       Scenario    Notes   2024-25     2025-26
-                N1      North West NSW  Step Change         73000000    74000000
-                Q9      Banana          Step Change         854000000   867000000
+            connection_cost_forecast_wind_and_solar:
+                REZ ID  Scenario      2024-25   2025-26
+                N1      Step Change   73000000  74000000
 
-            connection_costs_for_vre:
-                REZ ID  REZ names       Connection capacity (MVA)
-                N1      North West NSW  400
-                Q9      Banana          1800
+            connection_costs_for_wind_and_solar:
+                REZ ID  Connection capacity (MVA)
+                N1      400
 
-            system_strength_cost_table:
-                                        2024-25  2025-26
-                IBR remediation $/kW    163.24   148.88
+            connection_cost_forecast_other:
+                Generator Type  Region  Scenario      2024-25   2025-26
+                CCGT            NSW     Step Change   40000000  42000000
 
-            scenario: "Step Change"
+            connection_capacity_non_vre:
+                Region  Generator Type  Connection capacity (MVA)
+                NSW     CCGT            400
+
+            efficient_level_of_system_strength_cost:
+                                        2024-25   2025-26
+                IBR remediation $/kW    163.24    148.88
 
             generators_new_entrant:
-                name                    technology              geo_id
-                N1_WH_North West NSW    Wind                    N1
-                N1_SAT_North West NSW   Large scale Solar PV    N1
-                Q9_WH_Banana            Wind                    Q9
-                Q9_SAT_Banana           Large scale Solar PV    Q9
+                geo_id  technology
+                N1      Wind
+                N1      Large scale Solar PV
+                NNSW    CCGT
+
+            storage_new_entrant: (empty)
 
         Returns:
             geo_id  technology              year  connection_cost  system_strength_cost
-            N1      Wind                    2025  182500.00        163240.00  # VRE IBR: 163.24 $/kW * 1000
-            N1      Wind                    2026  185000.00        148880.00
-            N1      Large scale Solar PV    2025  182500.00        163240.00  # VRE IBR
-            N1      Large scale Solar PV    2026  185000.00        148880.00
-            Q9      Wind                    2025  474444.44        163240.00
-            Q9      Wind                    2026  481666.67        148880.00
-            Q9      Large scale Solar PV    2025  474444.44        163240.00
-            Q9      Large scale Solar PV    2026  481666.67        148880.00
+            N1      Wind                    2025  182500.0         163240.0  # VRE IBR
+            N1      Wind                    2026  185000.0         148880.0
+            N1      Large scale Solar PV    2025  182500.0         163240.0  # VRE IBR
+            N1      Large scale Solar PV    2026  185000.0         148880.0
+            NSW     CCGT                    2025  100000.0         0.0       # non-VRE, non-IBR
+            NSW     CCGT                    2026  105000.0         0.0
     """
 
     system_strength_costs = _normalise_system_strength_cost_frame(
-        system_strength_cost_table
+        iasr_tables["efficient_level_of_system_strength_cost"]
     )
 
-    vre_technologies_by_geo_id = _get_unique_vre_geo_id_rows(generators_new_entrant)
+    canonical_technology_geo_id_pairs = _get_canon_technology_and_geo_id_pairs(
+        generators_new_entrant, storage_new_entrant
+    )
+
     vre_connection_costs = _template_vre_connection_costs(
-        connection_cost_forecast_vre,
-        connection_costs_for_vre,
+        iasr_tables["connection_cost_forecast_wind_and_solar"],
+        iasr_tables["connection_costs_for_wind_and_solar"],
         scenario,
-        vre_technologies_by_geo_id,
+        canonical_technology_geo_id_pairs,
     )
-
-    # note: I started writing up non-VRE connection cost pipeline but there's some
-    # extra complexity there with batteries in REZs/BOTN being fussy/canonicalisation
-    # SO to keep this PR scope tight I've shifted that to a separate PR (next up).
-    non_vre_connection_costs = pd.DataFrame(
-        {
-            "geo_id": pd.Series(dtype="object"),
-            "technology": pd.Series(dtype="object"),
-            "year": pd.Series(dtype="int64"),
-            "connection_cost": pd.Series(dtype="float64"),
-        }
+    non_vre_connection_costs = _template_non_vre_connection_costs(
+        iasr_tables["connection_cost_forecast_other"],
+        iasr_tables["connection_capacity_non_vre"],
+        scenario,
+        canonical_technology_geo_id_pairs,
+        regional_granularity,
+        sub_regional_geography,
     )
 
     combined_connection_costs = pd.concat(
         [vre_connection_costs, non_vre_connection_costs], axis=0, ignore_index=True
     )
-
-    connection_costs = _merge_and_filter_system_strength_costs(
+    return _merge_and_filter_system_strength_costs(
         combined_connection_costs, system_strength_costs
     )
-    return connection_costs
+
+
+def _get_canon_technology_and_geo_id_pairs(
+    generators_new_entrant: pd.DataFrame, storage_new_entrant: pd.DataFrame
+) -> pd.DataFrame:
+    """Combines and deduplicates (geo_id, technology) pairs from new entrant generators
+    and storage tables."""
+    generators = generators_new_entrant[["geo_id", "technology"]].copy()
+    storage = storage_new_entrant[["geo_id", "technology"]].copy()
+    combined = pd.concat([generators, storage], axis=0, ignore_index=True)
+    return combined.drop_duplicates().reset_index(drop=True)
 
 
 # --- VRE connection costs ---
@@ -135,7 +168,7 @@ def _template_vre_connection_costs(
     connection_cost_forecast_vre: pd.DataFrame,
     connection_costs_for_vre: pd.DataFrame,
     scenario: str,
-    vre_technologies_by_geo_id: pd.DataFrame,
+    canonical_technology_geo_id_pairs: pd.DataFrame,
 ) -> pd.DataFrame:
     """Templates connection costs for VRE (wind and solar) new entrant technologies.
 
@@ -162,12 +195,14 @@ def _template_vre_connection_costs(
 
             scenario: "Step Change"
 
-            vre_technologies_by_geo_id:
+            canonical_technology_geo_id_pairs:
                 geo_id  technology
+                NNSW    CCGT
+                NNSW    Battery Storage (4h)
                 N1      Wind
                 N1      Large scale Solar PV
                 Q9      Large scale Solar PV
-                V8      Wind - offshore (fixed)     # included despite no cost forecast
+                V8      Wind - offshore (fixed)
 
         returns:
             geo_id  technology              year  connection_cost
@@ -180,6 +215,9 @@ def _template_vre_connection_costs(
             V8      Wind - offshore (fixed) 2025  NaN          # no forecast: expected
             V8      Wind - offshore (fixed) 2026  NaN          # system strength applied downstream
     """
+    vre_technologies_by_geo_id = _get_unique_vre_geo_id_rows(
+        canonical_technology_geo_id_pairs
+    )
     scenario_cost_forecast = _filter_table_by_isp_scenario(
         connection_cost_forecast_vre,
         scenario,
@@ -197,43 +235,38 @@ def _template_vre_connection_costs(
     return _build_vre_cost_rows(costs_per_mw, vre_technologies_by_geo_id)
 
 
-def _get_unique_vre_geo_id_rows(generators_new_entrant: pd.DataFrame) -> pd.DataFrame:
-    """Extracts unique (geo_id, technology) rows for non-distributed VRE technologies
-    from the templated new entrant generators table.
+def _get_unique_vre_geo_id_rows(canonical_tech_geo_ids: pd.DataFrame) -> pd.DataFrame:
+    """Extracts (geo_id, technology) rows for non-distributed VRE technologies
+    from the canonical technology/geo_id pairs.
 
-    Returns only rows where technology contains 'solar' or 'wind' (see ``_VRE_TECHNOLOGY_STRINGS``),
-    but not 'distributed', with duplicate (geo_id, technology) pairs removed.
+    Returns only rows where technology contains 'solar' or 'wind' (see
+    ``_VRE_TECHNOLOGY_STRINGS``), but not 'distributed'. Deduplication is the
+    caller's responsibility — the canonical pairs are already deduplicated upstream
+    by ``_get_canon_technology_and_geo_id_pairs``.
 
     I/O Example:
-        generators_new_entrant:
+        canonical_tech_geo_ids:
             geo_id  technology
             N1      Large scale Solar PV
-            N1      Large scale Solar PV            # duplicate: dropped
             N1      Wind
             NNSW    OCGT                            # non-VRE: excluded
             NNSW    Distributed Resources Solar     # 'distributed': excluded
-            Q9      Large scale Solar PV
-            V8      Wind - offshore (fixed)
 
         returns:
             geo_id  technology
             N1      Large scale Solar PV
             N1      Wind
-            Q9      Large scale Solar PV
-            V8      Wind - offshore (fixed)
     """
     vre_technologies = _where_any_substring_appears(
-        generators_new_entrant["technology"], _VRE_TECHNOLOGY_STRINGS
+        canonical_tech_geo_ids["technology"], _VRE_TECHNOLOGY_STRINGS
     )
     distributed_resources = _where_any_substring_appears(
-        generators_new_entrant["technology"], ["distributed"]
+        canonical_tech_geo_ids["technology"], ["distributed"]
     )
     rows_to_keep = vre_technologies & ~distributed_resources
-    return (
-        generators_new_entrant.loc[rows_to_keep, ["geo_id", "technology"]]
-        .drop_duplicates()
-        .reset_index(drop=True)
-    )
+    return canonical_tech_geo_ids.loc[
+        rows_to_keep, ["geo_id", "technology"]
+    ].reset_index(drop=True)
 
 
 def _build_vre_cost_rows(
@@ -255,16 +288,15 @@ def _build_vre_cost_rows(
             geo_id  year  connection_cost
             N1      2025  182500.0
             N1      2026  185000.0
-            Q9      2025  474444.4
-            Q9      2026  481666.7
+            R99     2025  474444.4  # R99 dropped - no VRE technology in canonical pairs
+            R99     2026  481666.7  # R99 dropped
             # V8 absent: no cost forecast defined for offshore REZs
 
         vre_technologies:
             geo_id  technology
             N1      Wind
             N1      Large scale Solar PV
-            Q9      Large scale Solar PV
-            V8      Wind - offshore (fixed)     # included despite no cost forecast
+            V8      Wind - offshore (fixed)
 
         returns:
             geo_id  technology              year  connection_cost
@@ -272,8 +304,6 @@ def _build_vre_cost_rows(
             N1      Wind                    2026  185000.0
             N1      Large scale Solar PV    2025  182500.0
             N1      Large scale Solar PV    2026  185000.0
-            Q9      Large scale Solar PV    2025  474444.4
-            Q9      Large scale Solar PV    2026  481666.7
             V8      Wind - offshore (fixed) 2025  NaN      # no forecast: NaN preserved
             V8      Wind - offshore (fixed) 2026  NaN
     """
@@ -283,6 +313,364 @@ def _build_vre_cost_rows(
         costs_per_mw[["geo_id", "year", "connection_cost"]],
         how="left",
         on=["geo_id", "year"],
+    )
+
+
+# --- Non-VRE connection costs ---
+
+
+def _template_non_vre_connection_costs(
+    connection_cost_forecast_other: pd.DataFrame,
+    connection_capacity_df: pd.DataFrame,
+    scenario: str,
+    canon_tech_geo_id_pairs: pd.DataFrame,
+    regional_granularity: str,
+    sub_regional_geography: pd.DataFrame,
+) -> pd.DataFrame:
+    """Templates connection costs for non-VRE new entrant technologies.
+
+    Filters the cost forecast to the given scenario, merges in connection capacity,
+    normalises to long format and $/MW units, canonicalises technology names, then
+    expands costs to geo_id level based on ``regional_granularity``. Batteries
+    located in REZs receive additional rows keyed to their REZ geo_id using costs
+    from their parent NEM region — see :func:`_create_additional_rez_battery_rows`.
+
+    ``canonical_technologies`` should be the union of technology names from the
+    templated new entrant generators and storage tables.
+
+    NOTE: 'BOTN - Cethana' is excluded (see ``_NON_VRE_EXCLUDED_TECHNOLOGIES``).
+    The IASR workbook defines a $0.0 connection cost for BOTN - Cethana, and it is
+    the only entry identified by name rather than technology type — TBD how to
+    handle it in the translator.
+
+    I/O Example:
+        connection_cost_forecast_other:
+            Generator Type          Region  Scenario        2024-25
+            CCGT                    NSW     Step Change     40000000
+            CCGT                    QLD     Step Change     36000000
+            Battery Storage (4h)    SA      Step Change     27000000
+
+        connection_capacity_df:
+            Region  Generator Type          Connection capacity (MVA)
+            NSW     CCGT                    400
+            QLD     CCGT                    300
+            SA      Battery Storage (4h)    300
+
+        scenario: "Step Change"
+
+        canon_tech_geo_id_pairs:
+            geo_id  technology
+            CNSW    CCGT
+            SNW     CCGT
+            NQ      CCGT
+            CSA     Battery Storage (4h)
+            S1      Battery Storage (4h)
+
+        regional_granularity: "sub_regions"
+
+        sub_regional_geography:
+            geo_id  geo_type    region_id
+            CNSW    subregion   NSW
+            SNW     subregion   NSW
+            NQ      subregion   QLD
+            CSA     subregion   SA
+            S1      rez         SA
+
+        returns:
+            geo_id  technology              year    connection_cost
+            CNSW    CCGT                    2025    100000.0
+            SNW     CCGT                    2025    100000.0
+            NQ      CCGT                    2025    120000.0
+            CSA     Battery Storage (4h)    2025    90000.0
+            S1      Battery Storage (4h)    2025    90000.0
+    """
+
+    scenario_cost_forecast = _filter_table_by_isp_scenario(
+        connection_cost_forecast_other,
+        scenario,
+        "Scenario",
+        "Non-VRE connection cost forecast",
+    )
+    merged_df = _merge_connection_cost_and_capacity_frames(
+        scenario_cost_forecast,
+        connection_capacity_df,
+        merge_cols=["Region", "Generator Type"],
+    )
+    normalised_df = _normalise_connection_cost_forecast_frame(
+        merged_df, id_cols_rename=_NON_VRE_COLUMN_RENAMES
+    )
+    canonical_technologies = set(canon_tech_geo_id_pairs["technology"])
+    canonicalised_df = _canonicalise_non_vre_technologies(
+        normalised_df, canonical_technologies
+    )
+    costs_per_mw = _calculate_connection_cost_per_mw(canonicalised_df)
+    _warn_nan_connection_costs(costs_per_mw, id_cols=["region_id", "technology"])
+    return _filter_connection_costs_by_regional_granularity(
+        costs_per_mw,
+        regional_granularity,
+        canon_tech_geo_id_pairs,
+        sub_regional_geography,
+    )
+
+
+def _canonicalise_non_vre_technologies(
+    df: pd.DataFrame, canonical_technologies: set[str]
+) -> pd.DataFrame:
+    """Drops unsupported technology rows and maps IASR names to canonical ISPyPSA names.
+
+    Removes rows for technologies listed in ``_NON_VRE_EXCLUDED_TECHNOLOGIES`` (special
+    cases, e.g. 'BOTN - Cethana' or not-yet-handled technologies). Remaining values in the
+    ``technology`` column are fuzzy-matched to ``canonical_technologies`` at
+    threshold=85; any value that cannot be matched raises ValueError.
+
+    NOTE: An empty canonical set means no new-entrant technologies are being
+    modelled (e.g. a brownfield-only run) — there is nothing to map costs onto,
+    so an empty df (with the same columns and dtypes as input df) is returned.
+
+    I/O Example:
+        df:
+            region_id  technology          year  connection_capacity  connection_cost
+            NSW        CCGT                2025  400                  40000000.0
+            NSW        OCGT small GT       2025  400                  32000000.0   # slight variation
+            TAS        BOTN - Cethana      2025  250                  0.0          # excluded explicitly
+            QLD        CCGT                2025  300                  36000000.0
+
+        canonical_technologies: {"CCGT", "OCGT (small GT)"}
+
+        returns:
+            region_id  technology       year  connection_capacity  connection_cost
+            NSW        CCGT             2025  400                  40000000.0
+            NSW        OCGT (small GT)  2025  400                  32000000.0  # fuzzy-matched
+            QLD        CCGT             2025  300                  36000000.0
+            # BOTN - Cethana row dropped (listed in ``_NON_VRE_EXCLUDED_TECHNOLOGIES``)
+    """
+    # NOTE: an only-VRE canonical set (non-empty, but no non-VRE techs) still raises
+    # via _fuzzy_map_to_canonical when the forecast has non-VRE rows.
+    # Intentional (for now) — kinda related to https://github.com/Open-ISP/ISPyPSA/discussions/103
+    if not canonical_technologies:
+        return pd.DataFrame(columns=df.columns).astype(df.dtypes)
+
+    excluded = _where_any_substring_appears(
+        df["technology"], _NON_VRE_EXCLUDED_TECHNOLOGIES
+    )
+    result = df.loc[~excluded].copy()
+    result["technology"] = _fuzzy_map_to_canonical(
+        result["technology"],
+        canonical_technologies,
+        task_desc="canonicalising non-VRE connection cost `technology` values",
+    )
+    return result
+
+
+def _create_non_vre_rez_cost_rows(
+    canon_tech_geo_id_pairs: pd.DataFrame,
+    sub_regional_geography: pd.DataFrame,
+    connection_costs: pd.DataFrame,
+) -> pd.DataFrame:
+    """Creates connection cost rows for non-VRE technology located in REZs, keyed by
+    the REZ geo_id.
+
+    At IASR workbook v7.5 this only includes 2h, 4h and 8h battery storage
+    technologies. Any non-VRE technologies defined in REZs that are not also
+    represented in the ``connection_costs`` dataframe will not have rows created.
+
+    I/O Example:
+        canon_tech_geo_id_pairs:
+            geo_id  technology
+            S1      Battery Storage (4h)    # REZ, non-VRE: included
+            S1      Wind                    # REZ, but VRE: excluded
+            NQ      CCGT                    # subregion, non-VRE: excluded
+
+        sub_regional_geography:
+            geo_id  geo_type  region_id
+            S1      rez       SA
+            NQ      subregion QLD
+
+        connection_costs:
+            region_id   technology              year    connection_cost
+            SA          Battery Storage (4h)    2025    90000.0
+            SA          Battery Storage (4h)    2026    94500.0
+            QLD         CCGT                    2025    100000.0
+            QLD         CCGT                    2026    120000.0
+
+        returns:
+            geo_id  technology              year  connection_cost
+            S1      Battery Storage (4h)    2025  90000.0   # SA cost applied to REZ S1
+            S1      Battery Storage (4h)    2026  94500.0
+    """
+    rezs_by_region = sub_regional_geography.loc[
+        sub_regional_geography["geo_type"] == "rez", ["geo_id", "region_id"]
+    ]
+    in_rez = canon_tech_geo_id_pairs["geo_id"].isin(set(rezs_by_region["geo_id"]))
+    non_vre = ~_where_any_substring_appears(
+        canon_tech_geo_id_pairs["technology"], _VRE_TECHNOLOGY_STRINGS
+    )
+    rez_technologies = canon_tech_geo_id_pairs[in_rez & non_vre].merge(
+        rezs_by_region, how="left", on="geo_id"
+    )
+    additional_rows = rez_technologies.merge(
+        connection_costs, how="inner", on=["region_id", "technology"]
+    )
+    return additional_rows.drop(columns=["region_id"])
+
+
+def _filter_connection_costs_by_regional_granularity(
+    non_vre_connection_costs: pd.DataFrame,
+    regional_granularity: str,
+    canon_tech_geo_id_pairs: pd.DataFrame,
+    sub_regional_geography: pd.DataFrame,
+) -> pd.DataFrame:
+    """Converts region-level non-VRE costs to geo_id-level based on granularity, and
+    appends additional rows for batteries located in REZs.
+
+    Three granularity branches are supported:
+    - ``"nem_regions"``:   one row per NEM region (region_id renamed to geo_id)
+    - ``"sub_regions"``:   one row per sub-region — see
+      :func:`_expand_non_vre_connection_costs_to_subregions`
+    - ``"single_region"``: all regions averaged to a single "NEM" geo_id — see
+      :func:`_average_connection_costs_across_regions`
+
+    Non-VRE technologies defined in REZs (from ``canon_tech_geo_id_pairs``) are
+    appended in all branches with their REZ geo_id and costs inherited from the
+    parent NEM region — see :func:`_create_non_vre_rez_cost_rows`.
+
+    I/O Example:
+
+        Inputs:
+            non_vre_connection_costs:
+                region_id  technology              year  connection_cost
+                NSW        CCGT                    2025  100000.0    # 40000000 / 400
+                NSW        Battery Storage (4h)    2025  50000.0     # 20000000 / 400
+                QLD        CCGT                    2025  120000.0    # 36000000 / 300
+                QLD        Battery Storage (4h)    2025  60000.0     # 18000000 / 300
+
+            canon_tech_geo_id_pairs:
+                geo_id  technology
+                N1      Battery Storage (4h)    # REZ: extra row created for N1
+                SNW     Battery Storage (4h)
+                SNW     CCGT
+                CQ      Battery Storage (4h)
+                CQ      CCGT
+                NQ      Battery Storage (4h)
+                NQ      CCGT
+
+            sub_regional_geography:
+                geo_id  geo_type    region_id
+                N1      rez         NSW
+                SNW     subregion   NSW
+                CQ      subregion   QLD
+                NQ      subregion   QLD
+
+        Returns:
+            regional_granularity = "nem_regions":
+                geo_id  technology              year  connection_cost
+                NSW     CCGT                    2025  100000.0    # region_id -> geo_id
+                NSW     Battery Storage (4h)    2025  50000.0
+                QLD     CCGT                    2025  120000.0
+                QLD     Battery Storage (4h)    2025  60000.0
+                N1      Battery Storage (4h)    2025  50000.0     # REZ row appended (NSW cost)
+
+            regional_granularity = "sub_regions":
+                geo_id  technology              year  connection_cost
+                SNW     CCGT                    2025  100000.0
+                SNW     Battery Storage (4h)    2025  50000.0
+                CQ      CCGT                    2025  120000.0    # QLD costs applied
+                CQ      Battery Storage (4h)    2025  60000.0
+                NQ      CCGT                    2025  120000.0
+                NQ      Battery Storage (4h)    2025  60000.0
+                N1      Battery Storage (4h)    2025  50000.0     # REZ row appended (NSW cost)
+
+            regional_granularity = "single_region":
+                geo_id  technology              year  connection_cost
+                NEM     CCGT                    2025  110000.0    # mean(100000, 120000)
+                NEM     Battery Storage (4h)    2025  55000.0     # mean(50000, 60000)
+                N1      Battery Storage (4h)    2025  50000.0     # REZ row: NSW cost, not averaged
+    """
+    rez_non_vre_rows = _create_non_vre_rez_cost_rows(
+        canon_tech_geo_id_pairs, sub_regional_geography, non_vre_connection_costs
+    )
+
+    if regional_granularity == "nem_regions":
+        connection_costs = non_vre_connection_costs.rename(
+            columns={"region_id": "geo_id"}
+        )
+    elif regional_granularity == "sub_regions":
+        connection_costs = _expand_non_vre_connection_costs_to_subregions(
+            non_vre_connection_costs, sub_regional_geography
+        )
+    elif regional_granularity == "single_region":
+        connection_costs = _average_connection_costs_across_regions(
+            non_vre_connection_costs
+        )
+    else:
+        raise ValueError(f"Unknown regional_granularity: {regional_granularity!r}")
+
+    combined = pd.concat(
+        [connection_costs, rez_non_vre_rows], axis=0, ignore_index=True
+    )
+    return combined[["geo_id", "technology", "year", "connection_cost"]]
+
+
+def _expand_non_vre_connection_costs_to_subregions(
+    non_vre_connection_costs: pd.DataFrame, sub_regional_geography: pd.DataFrame
+) -> pd.DataFrame:
+    """Expands region-level connection costs to one row per subregion by merging
+    with the subregion rows from the network geography table.
+
+    I/O Example:
+        non_vre_connection_costs:
+            region_id  technology       year  connection_cost
+            QLD        OCGT (small GT)  2025  120000.0    # 36000000 / 300
+            NSW        OCGT (small GT)  2025  100000.0    # 40000000 / 400
+
+        sub_regional_geography:
+            geo_id  geo_type    region_id
+            Q9      rez         QLD          # REZ rows ignored (inner merge on subregion only)
+            NQ      subregion   QLD
+            CQ      subregion   QLD
+            NNSW    subregion   NSW
+            SNW     subregion   NSW
+
+        returns:
+            geo_id  technology       year  connection_cost
+            NQ      OCGT (small GT)  2025  120000.0
+            CQ      OCGT (small GT)  2025  120000.0
+            NNSW    OCGT (small GT)  2025  100000.0
+            SNW     OCGT (small GT)  2025  100000.0
+    """
+    subregion_geo_type = sub_regional_geography.loc[
+        sub_regional_geography["geo_type"] == "subregion", ["geo_id", "region_id"]
+    ]
+    connection_costs_by_subregion = subregion_geo_type.merge(
+        non_vre_connection_costs, how="inner", on=["region_id"]
+    )
+    return connection_costs_by_subregion.drop(columns=["region_id"])
+
+
+def _average_connection_costs_across_regions(
+    non_vre_connection_costs: pd.DataFrame,
+) -> pd.DataFrame:
+    """Averages connection costs across NEM regions and assigns geo_id="NEM".
+
+    Used for the single_region granularity where all regions and subregions are
+    collapsed to one aggregate "NEM".
+
+    I/O Example:
+        non_vre_connection_costs:
+            region_id  technology       year  connection_cost
+            NSW        OCGT (small GT)  2025  100000.0
+            QLD        OCGT (small GT)  2025  120000.0
+            VIC        OCGT (small GT)  2025  80000.0
+
+        returns:
+            geo_id  technology       year  connection_cost
+            NEM     OCGT (small GT)  2025  100000.0    # mean(100000, 120000, 80000)
+    """
+    return (
+        non_vre_connection_costs.assign(geo_id="NEM")
+        .groupby(["geo_id", "technology", "year"])["connection_cost"]
+        .mean()
+        .reset_index()
     )
 
 
@@ -302,20 +690,20 @@ def _merge_and_filter_system_strength_costs(
 
     I/O Example:
         connection_costs:
-            geo_id  technology    year  connection_cost
-            N1      Solar         2025  1825000.0
-            N1      Wind          2025  1825000.0
-            QLD     Small OCGT    2025  500000.0
+            geo_id  technology              year  connection_cost
+            N1      Large scale Solar PV    2025  182500.0
+            N1      Wind                    2025  182500.0
+            NSW     OCGT (small GT)         2025  100000.0
 
         system_strength_costs:
             year  system_strength_cost
-            2025  10000.0
+            2025  163240.0
 
         returns:
-            geo_id  technology    year  connection_cost  system_strength_cost
-            N1      Solar         2025  1825000.0        10000.0
-            N1      Wind          2025  1825000.0        10000.0
-            QLD     Small OCGT    2025  500000.0         0.0
+            geo_id  technology              year  connection_cost  system_strength_cost
+            N1      Large scale Solar PV    2025  182500.0         163240.0  # IBR: cost applied
+            N1      Wind                    2025  182500.0         163240.0  # IBR: cost applied
+            NSW     OCGT (small GT)         2025  100000.0         0.0       # non-IBR: zeroed
     """
     costs = connection_costs.merge(system_strength_costs, how="left", on=["year"])
     costs = _set_non_ibr_system_strength_cost_to_zero(costs)
@@ -342,11 +730,20 @@ def _normalise_system_strength_cost_frame(
             2025  10000.0    # 10 $/kW * 1000 = 10000 $/MW
             2026  12000.0
     """
-    year_cols = [
-        c for c in system_strength_cost_table.columns if _looks_like_financial_year(c)
-    ]
+
+    # NOTE: ``efficient_level_of_system_strength_cost`` table direct from IASR
+    # has some 'year' columns that are formatted as '2032-2033' (those years onwards)
+    # manual fix here:
+    year_cols = {
+        c: c.replace("-20", "-", 1)
+        for c in system_strength_cost_table.columns
+        if _looks_like_financial_year(c.replace("-20", "-", 1))
+    }
+    system_strength_cost_table = system_strength_cost_table.rename(columns=year_cols)
     long_system_strength_costs = system_strength_cost_table.melt(
-        value_vars=year_cols, value_name="system_strength_cost", var_name="year"
+        value_vars=list(year_cols.values()),
+        value_name="system_strength_cost",
+        var_name="year",
     )
     long_system_strength_costs["system_strength_cost"] = pd.to_numeric(
         long_system_strength_costs["system_strength_cost"], errors="coerce"
@@ -376,12 +773,7 @@ def _set_non_ibr_system_strength_cost_to_zero(
 def _set_solar_thermal_system_strength_costs_to_zero(
     connection_costs: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Sets system_strength_cost to 0.0 for solar thermal technologies.
-
-    Solar thermal matches 'solar' in ``_IBR_TECHNOLOGY_STRINGS`` but is not
-    an inverter-based resource, so its system strength cost is zeroed separately
-    after the IBR filter.
-    """
+    """Sets system_strength_cost to 0.0 for solar thermal technologies."""
     solar_thermal_rows = _where_any_substring_appears(
         connection_costs["technology"], ["solar thermal"]
     )
@@ -403,26 +795,19 @@ def _normalise_connection_cost_forecast_frame(
     Empty/null/NaN values are retained.
 
     I/O Example:
-        connection_cost_forecast (VRE example):
-            REZ ID  REZ names       Connection capacity (MVA)   2024-25     2025-26
-            N1      North West NSW  400                         730000000   740000000
-            Q9      Banana          1800                        8540000000  8670000000
-            R12     New REZ         150                         NaN         NaN
+        connection_cost_forecast (VRE):
+            REZ ID  Connection capacity (MVA)   2024-25
+            N1      400                         73000000
+            Q9      1800                        854000000
+            R99     150                         NaN         # R99: fictional REZ, no cost data
 
-        id_cols_rename:
-            {
-                "REZ ID" : "geo_id",
-                "Connection capacity (MVA)": "connection_capacity"
-            }
+        id_cols_rename: {"REZ ID": "geo_id", "Connection capacity (MVA)": "connection_capacity"}
 
         returns:
-            geo_id  year    connection_capacity     connection_cost
-            N1      2025    400                     730000000
-            N1      2026    400                     740000000
-            Q9      2025    1800                    8540000000
-            Q9      2026    1800                    8670000000
-            R12     2025    150                     NaN                # R12 NaN value returned
-            R12     2026    150                     NaN                # R12 NaN value returned
+            geo_id  year  connection_capacity  connection_cost
+            N1      2025  400                  73000000
+            Q9      2025  1800                 854000000
+            R99     2025  150                  NaN          # NaN preserved
     """
 
     year_cols = [
@@ -438,9 +823,7 @@ def _normalise_connection_cost_forecast_frame(
     melted = melted.rename(columns=id_cols_rename)
     melted = _enforce_numeric_cols(melted, ["connection_cost", "connection_capacity"])
     melted["year"] = melted["year"].map(_financial_year_string_to_end_year_int)
-    return melted[
-        ["geo_id", "year", "connection_capacity", "connection_cost"]
-    ].reset_index(drop=True)
+    return melted
 
 
 def _enforce_numeric_cols(df: pd.DataFrame, numeric_cols: list[str]) -> pd.DataFrame:
@@ -467,22 +850,22 @@ def _calculate_connection_cost_per_mw(
 ) -> pd.DataFrame:
     """Divides total connection cost by connection capacity to return $/MW connection cost.
 
-    Division by zero (inf) is replaced with pd.NA. NaN cost inputs are preserved.
+    Division by zero (inf) is replaced with NaN. NaN cost inputs are preserved.
 
     I/O Example:
         cost_and_capacity_df:
             geo_id  connection_capacity  year  connection_cost
-            N1      400                  2025  730000000.0
-            Q9      1800                 2025  8540000000.0
-            R12     150                  2025  NaN            # NaN: no cost data
-            R13     0                    2025  120000000.0    # Becomes NaN - capacity = 0.0
+            N1      400                  2025  73000000.0
+            Q9      1800                 2025  854000000.0
+            R98     150                  2025  NaN            # no cost data → NaN preserved
+            R99     0                    2025  12000000.0     # capacity = 0 → inf → NaN
 
         returns:
             geo_id  year  connection_cost
-            N1      2025  1825000.0      # $73M / 400
-            Q9      2025  4744444.4      # $854M / 1800
-            R12     2025  NaN            # NaN / 150 -> NaN
-            R13     2025  NaN            # $12M / 0.0 -> set to NaN
+            N1      2025  182500.0      # 73000000 / 400
+            Q9      2025  474444.4      # 854000000 / 1800
+            R98     2025  NaN           # NaN / 150 -> NaN
+            R99     2025  NaN           # 12000000 / 0 -> inf -> NaN
     """
     costs_per_mw = cost_and_capacity_df.copy()
     costs_per_mw["connection_cost"] = (
@@ -511,12 +894,15 @@ def _warn_nan_connection_costs(
     identifiers = sorted(
         nan_rows[log_cols].drop_duplicates().itertuples(index=False, name=None)
     )
+    all_nan_costs = []
     for id_vals in identifiers:
         id_val_string = ", ".join(f"{col}={val}" for col, val in zip(log_cols, id_vals))
-        logging.warning(
-            f"NaN connection cost after per-MW calculation for: ({id_val_string}) "
-            "— no additional connection cost will be applied here"
-        )
+        all_nan_costs.append(id_val_string)
+
+    logging.warning(
+        f"NaN connection cost after per-MW calculation for: {all_nan_costs} "
+        "— no additional connection cost will be applied here"
+    )
 
 
 # temp define here helper function for scenario filtering
@@ -538,7 +924,7 @@ def _filter_table_by_isp_scenario(
 
         returns:
             Region      2025-26     2026-27
-            NSW         100         300
+            NSW         100         150
     """
     table = table.copy()
     table[scenario_col_name] = _fuzzy_map_to_canonical(

--- a/src/ispypsa/templater/connection_and_build_costs.py
+++ b/src/ispypsa/templater/connection_and_build_costs.py
@@ -224,8 +224,8 @@ def _template_vre_connection_costs(
         "Scenario",
         "VRE connection cost forecast",
     )
-    merged_df = _merge_connection_cost_and_capacity_frames(
-        scenario_cost_forecast, connection_costs_for_vre, ["REZ ID"]
+    merged_df = scenario_cost_forecast.merge(
+        connection_costs_for_vre, how="left", on=["REZ ID"]
     )
     normalised_df = _normalise_connection_cost_forecast_frame(
         merged_df, id_cols_rename=_VRE_COLUMN_RENAMES
@@ -391,10 +391,8 @@ def _template_non_vre_connection_costs(
         "Scenario",
         "Non-VRE connection cost forecast",
     )
-    merged_df = _merge_connection_cost_and_capacity_frames(
-        scenario_cost_forecast,
-        connection_capacity_df,
-        merge_cols=["Region", "Generator Type"],
+    merged_df = scenario_cost_forecast.merge(
+        connection_capacity_df, how="left", on=["Region", "Generator Type"]
     )
     normalised_df = _normalise_connection_cost_forecast_frame(
         merged_df, id_cols_rename=_NON_VRE_COLUMN_RENAMES
@@ -446,7 +444,7 @@ def _canonicalise_non_vre_technologies(
     """
     # NOTE: an only-VRE canonical set (non-empty, but no non-VRE techs) still raises
     # via _fuzzy_map_to_canonical when the forecast has non-VRE rows.
-    # Intentional (for now) — kinda related to https://github.com/Open-ISP/ISPyPSA/discussions/103
+    # Intentional (for now) — kinda related to https://github.com/Open-ISP/ISPyPSA/discussions/103 and the final role(s) of validator.
     if not canonical_technologies:
         return pd.DataFrame(columns=df.columns).astype(df.dtypes)
 
@@ -831,18 +829,6 @@ def _enforce_numeric_cols(df: pd.DataFrame, numeric_cols: list[str]) -> pd.DataF
     for col in numeric_cols:
         df[col] = pd.to_numeric(df[col], errors="coerce")
     return df
-
-
-def _merge_connection_cost_and_capacity_frames(
-    cost_df: pd.DataFrame, capacity_df: pd.DataFrame, merge_cols: list[str]
-) -> pd.DataFrame:
-    """Left-merges cost forecast with connection capacity on ``merge_cols``.
-
-    Note: for VRE connection costs, REZ IDs present only in ``capacity_df`` are
-    dropped; offshore REZs with no cost forecast are handled downstream by
-    ``_build_vre_cost_rows``.
-    """
-    return cost_df.merge(capacity_df, how="left", on=merge_cols)
 
 
 def _calculate_connection_cost_per_mw(

--- a/src/ispypsa/templater/create_template.py
+++ b/src/ispypsa/templater/create_template.py
@@ -223,13 +223,23 @@ def create_ispypsa_inputs_template(
         # todo: replace with actual generators_new_entrant once that templating
         # function is written — passing empty placeholder for now so costs_connection
         # is wired up but produces no VRE rows until generators are templated.
+
+        # connection_capacity_non_vre is in manually_extracted_template_tables/ (sourced from
+        # ENOR tables 16-17 and confirmed with AEMO) but is needed as an iasr_tables input,
+        # not a template output.
+        iasr_tables["connection_capacity_non_vre"] = manually_extracted_tables.pop(
+            "connection_capacity_non_vre"
+        )
+
         generators_new_entrant = pd.DataFrame(columns=["geo_id", "technology"])
+        storage_new_entrant = pd.DataFrame(columns=["geo_id", "technology"])
         template["costs_connection"] = _template_connection_costs(
-            iasr_tables["connection_cost_forecast_wind_and_solar"],
-            iasr_tables["connection_costs_for_wind_and_solar"],
-            iasr_tables["efficient_level_of_system_strength_cost"],
+            iasr_tables,
             scenario,
+            regional_granularity,
             generators_new_entrant,
+            storage_new_entrant,
+            sub_regional_geography,
         )
         # Custom constraints from PLEXOS are sub-regional export-group limits:
         # their LHS references sub-region nodes, sub-regional flow paths, and

--- a/src/ispypsa/templater/create_template.py
+++ b/src/ispypsa/templater/create_template.py
@@ -226,10 +226,11 @@ def create_ispypsa_inputs_template(
 
         # connection_capacity_non_vre is in manually_extracted_template_tables/ (sourced from
         # ENOR tables 16-17 and confirmed with AEMO) but is needed as an iasr_tables input,
-        # not a template output.
-        iasr_tables["connection_capacity_non_vre"] = manually_extracted_tables.pop(
+        # not a template output. TODO revisit when more manual tables added and consider
+        # reading direct from disk in templater functions vs. dict as input here.
+        iasr_tables["connection_capacity_non_vre"] = manually_extracted_tables[
             "connection_capacity_non_vre"
-        )
+        ].copy()
 
         generators_new_entrant = pd.DataFrame(columns=["geo_id", "technology"])
         storage_new_entrant = pd.DataFrame(columns=["geo_id", "technology"])

--- a/src/ispypsa/templater/helpers.py
+++ b/src/ispypsa/templater/helpers.py
@@ -304,7 +304,7 @@ def _add_units_to_financial_year_columns(
 
 
 def _looks_like_financial_year(col: str) -> bool:
-    """True if column name matches a financial year pattern like '2024-25'."""
+    """True if column name matches a financial year pattern like '2024-25'"""
     return bool(re.match(r"^\d{4}-\d{2}$", str(col)))
 
 

--- a/src/ispypsa/templater/manual_tables.py
+++ b/src/ispypsa/templater/manual_tables.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 def load_manually_extracted_tables(
     iasr_workbook_version: str,
-) -> dict[str : pd.DataFrame]:
+) -> dict[str, pd.DataFrame]:
     """Retrieves the manually extracted template files for the IASR workbook version.
 
     Some tables can't be handled by `isp-workbook-parser` so ISPyPSA ships with the

--- a/src/ispypsa/templater/manually_extracted_template_tables/7.5/connection_capacity_non_vre.csv
+++ b/src/ispypsa/templater/manually_extracted_template_tables/7.5/connection_capacity_non_vre.csv
@@ -1,0 +1,81 @@
+﻿Region,Generator Type,Connection capacity (MVA)
+QLD,CCGT,300
+QLD,CCGT with CCS,300
+QLD,OCGT (small GT),300
+QLD,OCGT (large GT),300
+QLD,Distributed Resources Solar,300
+QLD,Distributed Resources Batteries,300
+QLD,Biomass,300
+QLD,Battery storage (1hr storage),300
+QLD,Battery storage (2hrs storage),300
+QLD,Battery storage (4hrs storage),300
+QLD,Battery Storage (8hrs storage),300
+QLD,Pumped Hydro (10hrs storage),300
+QLD,Pumped Hydro (24hrs storage),300
+QLD,Pumped Hydro (48hrs storage),300
+QLD,Alkaline Electrolyser,300
+QLD,BOTN - Cethana,300
+NSW,CCGT,400
+NSW,CCGT with CCS,400
+NSW,OCGT (small GT),400
+NSW,OCGT (large GT),400
+NSW,Distributed Resources Solar,400
+NSW,Distributed Resources Batteries,400
+NSW,Biomass,400
+NSW,Battery storage (1hr storage),400
+NSW,Battery storage (2hrs storage),400
+NSW,Battery storage (4hrs storage),400
+NSW,Battery Storage (8hrs storage),400
+NSW,Pumped Hydro (10hrs storage),400
+NSW,Pumped Hydro (24hrs storage),400
+NSW,Pumped Hydro (48hrs storage),400
+NSW,Alkaline Electrolyser,400
+NSW,BOTN - Cethana,400
+VIC,CCGT,600
+VIC,CCGT with CCS,600
+VIC,OCGT (small GT),250
+VIC,OCGT (large GT),250
+VIC,Distributed Resources Solar,250
+VIC,Distributed Resources Batteries,250
+VIC,Biomass,250
+VIC,Battery storage (1hr storage),250
+VIC,Battery storage (2hrs storage),250
+VIC,Battery storage (4hrs storage),250
+VIC,Battery Storage (8hrs storage),250
+VIC,Pumped Hydro (10hrs storage),250
+VIC,Pumped Hydro (24hrs storage),250
+VIC,Pumped Hydro (48hrs storage),250
+VIC,Alkaline Electrolyser,250
+VIC,BOTN - Cethana,250
+SA,CCGT,300
+SA,CCGT with CCS,300
+SA,OCGT (small GT),300
+SA,OCGT (large GT),300
+SA,Distributed Resources Solar,300
+SA,Distributed Resources Batteries,300
+SA,Biomass,300
+SA,Battery storage (1hr storage),300
+SA,Battery storage (2hrs storage),300
+SA,Battery storage (4hrs storage),300
+SA,Battery Storage (8hrs storage),300
+SA,Pumped Hydro (10hrs storage),300
+SA,Pumped Hydro (24hrs storage),300
+SA,Pumped Hydro (48hrs storage),300
+SA,Alkaline Electrolyser,300
+SA,BOTN - Cethana,300
+TAS,CCGT,250
+TAS,CCGT with CCS,250
+TAS,OCGT (small GT),250
+TAS,OCGT (large GT),250
+TAS,Distributed Resources Solar,250
+TAS,Distributed Resources Batteries,250
+TAS,Biomass,250
+TAS,Battery storage (1hr storage),250
+TAS,Battery storage (2hrs storage),250
+TAS,Battery storage (4hrs storage),250
+TAS,Battery Storage (8hrs storage),250
+TAS,Pumped Hydro (10hrs storage),250
+TAS,Pumped Hydro (24hrs storage),250
+TAS,Pumped Hydro (48hrs storage),250
+TAS,Alkaline Electrolyser,250
+TAS,BOTN - Cethana,250

--- a/tests/test_templater/test_connection_and_build_costs.py
+++ b/tests/test_templater/test_connection_and_build_costs.py
@@ -1,11 +1,19 @@
 import pandas as pd
+import pytest
 
 from ispypsa.templater.connection_and_build_costs import (
+    _NON_VRE_COLUMN_RENAMES,
     _VRE_COLUMN_RENAMES,
+    _average_connection_costs_across_regions,
     _build_vre_cost_rows,
     _calculate_connection_cost_per_mw,
+    _canonicalise_non_vre_technologies,
+    _create_non_vre_rez_cost_rows,
     _enforce_numeric_cols,
+    _expand_non_vre_connection_costs_to_subregions,
+    _filter_connection_costs_by_regional_granularity,
     _filter_table_by_isp_scenario,
+    _get_canon_technology_and_geo_id_pairs,
     _get_unique_vre_geo_id_rows,
     _merge_and_filter_system_strength_costs,
     _merge_connection_cost_and_capacity_frames,
@@ -14,6 +22,7 @@ from ispypsa.templater.connection_and_build_costs import (
     _set_non_ibr_system_strength_cost_to_zero,
     _set_solar_thermal_system_strength_costs_to_zero,
     _template_connection_costs,
+    _template_non_vre_connection_costs,
     _template_vre_connection_costs,
     _warn_nan_connection_costs,
 )
@@ -133,15 +142,44 @@ def test_normalise_connection_cost_forecast_frame(csv_str_to_df):
     )
 
     expected = csv_str_to_df("""
-        geo_id,  year,  connection_capacity,  connection_cost
-        N1,      2025,  400.0,                730000000.0
-        N1,      2026,  400.0,                740000000.0
-        Q9,      2025,  1800.0,               8540000000.0
-        Q9,      2026,  1800.0,               8670000000.0
+        geo_id,  connection_capacity,  year,  connection_cost
+        N1,      400.0,                2025,  730000000.0
+        N1,      400.0,                2026,  740000000.0
+        Q9,      1800.0,               2025,  8540000000.0
+        Q9,      1800.0,               2026,  8670000000.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(["geo_id", "year"]).reset_index(drop=True),
         expected.sort_values(["geo_id", "year"]).reset_index(drop=True),
+        check_exact=False,
+        rtol=1e-5,
+        check_dtype=False,
+    )
+
+
+def test_normalise_connection_cost_forecast_frame_non_vre_renames(csv_str_to_df):
+    # Non-VRE path melts with a 3-key rename dict (Region, Generator Type,
+    # capacity) — a different, multi-id-column shape from the VRE case above.
+    connection_cost_forecast = csv_str_to_df("""
+        Region,  Generator__Type,  Connection__capacity__(MVA),  2024-25,   2025-26
+        NSW,     CCGT,             400,                          40000000,  42000000
+        QLD,     CCGT,             300,                          36000000,  37000000
+    """)
+
+    result = _normalise_connection_cost_forecast_frame(
+        connection_cost_forecast, id_cols_rename=_NON_VRE_COLUMN_RENAMES
+    )
+
+    expected = csv_str_to_df("""
+        region_id,  technology,  connection_capacity,  year,  connection_cost
+        NSW,        CCGT,        400.0,                2025,  40000000.0
+        NSW,        CCGT,        400.0,                2026,  42000000.0
+        QLD,        CCGT,        300.0,                2025,  36000000.0
+        QLD,        CCGT,        300.0,                2026,  37000000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values(["region_id", "year"]).reset_index(drop=True),
+        expected.sort_values(["region_id", "year"]).reset_index(drop=True),
         check_exact=False,
         rtol=1e-5,
         check_dtype=False,
@@ -161,9 +199,9 @@ def test_normalise_connection_cost_forecast_frame_preserves_nan_rows(csv_str_to_
     )
 
     expected = csv_str_to_df("""
-        geo_id,     year,   connection_capacity,    connection_cost
-        DN1,        2025,   150.0,
-        Q1,         2025,   ,                       160000000.0
+        geo_id,     connection_capacity,    year,   connection_cost
+        DN1,        150.0,                  2025,
+        Q1,         ,                       2025,   160000000.0
     """)
     pd.testing.assert_frame_equal(
         result.reset_index(drop=True),
@@ -182,7 +220,7 @@ def test_normalise_connection_cost_forecast_frame_empty_input(csv_str_to_df):
     )
 
     expected = csv_str_to_df("""
-        geo_id,     year,   connection_capacity,    connection_cost
+        geo_id,     connection_capacity,    year,   connection_cost
     """)
 
     pd.testing.assert_frame_equal(
@@ -353,7 +391,7 @@ def test_warn_nan_connection_costs_logs_warning_with_identifiers(csv_str_to_df, 
         _warn_nan_connection_costs(costs, id_cols=["geo_id"])
 
     msg = (
-        "NaN connection cost after per-MW calculation for: (geo_id=DN1, year=2025) "
+        "NaN connection cost after per-MW calculation for: ['geo_id=DN1, year=2025'] "
         "— no additional connection cost will be applied here"
     )
     assert msg in caplog.text
@@ -381,10 +419,11 @@ def test_warn_nan_connection_costs_no_warning_when_all_costs_valid(
 def test_normalise_system_strength_cost_frame(csv_str_to_df):
     # Wide single-row table → long (year, system_strength_cost).
     # $/kW * 1000 = $/MW conversion applied.
-    # FY strings converted to year int. Non-year label column dropped.
+    # FY strings converted to year int, long-form year string fix applied correctly.
+    # Non-year label column dropped.
     system_strength_cost_table = csv_str_to_df("""
-        label,            2024-25,  2025-26,    Notes
-        IBR__remediation, 10,       12,         Some__extra__note
+        label,            2024-25,  2025-26,    2026-2027,      Notes
+        IBR__remediation, 10,       12,         15,             Some__extra__note
     """)
 
     result = _normalise_system_strength_cost_frame(system_strength_cost_table)
@@ -393,6 +432,7 @@ def test_normalise_system_strength_cost_frame(csv_str_to_df):
         year,  system_strength_cost
         2025,  10000.0
         2026,  12000.0
+        2027,  15000.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values("year").reset_index(drop=True),
@@ -601,11 +641,11 @@ def test_merge_and_filter_system_strength_costs_empty_inputs(csv_str_to_df):
 
 
 def test_get_unique_vre_geo_id_rows(csv_str_to_df):
-    # Non-VRE rows (Pumped Hydro) are excluded. 'Distributed' rows excluded.
-    # Duplicate (N1, Solar PV) rows are deduplicated to one.
-    generators_new_entrant = csv_str_to_df("""
+    # Non-VRE rows (Pumped Hydro) are excluded. 'Distributed' rows excluded
+    # (including 'Distributed Resources Solar' despite containing 'solar').
+    # Input is assumed already deduplicated upstream — this function does not dedup.
+    canonical_tech_geo_ids = csv_str_to_df("""
         geo_id,  technology
-        N1,      Large__scale__Solar__PV
         N1,      Large__scale__Solar__PV
         N1,      Wind
         NNSW,    Pumped__Hydro__(24hrs__storage)
@@ -615,7 +655,7 @@ def test_get_unique_vre_geo_id_rows(csv_str_to_df):
         SESA,    Distributed__Resources__Solar
     """)
 
-    result = _get_unique_vre_geo_id_rows(generators_new_entrant)
+    result = _get_unique_vre_geo_id_rows(canonical_tech_geo_ids)
 
     expected = csv_str_to_df("""
         geo_id,  technology
@@ -861,61 +901,507 @@ def test_template_vre_connection_costs_empty_capacity_gives_nan_costs(csv_str_to
     )
 
 
+# --- _get_canon_technology_and_geo_id_pairs ---
+
+
+def test_get_canon_technology_and_geo_id_pairs(csv_str_to_df):
+    # Union of generator and storage (geo_id, technology) pairs, deduplicated.
+    # (CNSW, CCGT) appears in both tables and as a within-table duplicate → one row.
+    generators_new_entrant = csv_str_to_df("""
+        geo_id,  technology
+        N1,      Wind
+        CNSW,    CCGT
+        CNSW,    CCGT
+    """)
+    storage_new_entrant = csv_str_to_df("""
+        geo_id,  technology
+        CNSW,    Battery__Storage__(4h)
+        CNSW,    CCGT
+    """)
+
+    result = _get_canon_technology_and_geo_id_pairs(
+        generators_new_entrant, storage_new_entrant
+    )
+
+    expected = csv_str_to_df("""
+        geo_id,  technology
+        N1,      Wind
+        CNSW,    CCGT
+        CNSW,    Battery__Storage__(4h)
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values(_GEO_TECH_COLS).reset_index(drop=True),
+        expected.sort_values(_GEO_TECH_COLS).reset_index(drop=True),
+    )
+
+
+# --- _canonicalise_non_vre_technologies ---
+
+
+def test_canonicalise_non_vre_technologies(csv_str_to_df):
+    # Excluded techs dropped; remaining values fuzzy-mapped to canonical names.
+    df = csv_str_to_df("""
+        region_id,  technology,         year,  connection_capacity,  connection_cost
+        NSW,        CCGT,               2025,  400,                  40000000.0
+        NSW,        OCGT__small__GT,    2025,  400,                  32000000.0
+        TAS,        BOTN__-__Cethana,   2025,  250,                  0.0
+    """)
+    canonical_technologies = {"CCGT", "OCGT (small GT)"}
+
+    result = _canonicalise_non_vre_technologies(df, canonical_technologies)
+
+    expected = csv_str_to_df("""
+        region_id,  technology,         year,  connection_capacity,  connection_cost
+        NSW,        CCGT,               2025,  400,                  40000000.0
+        NSW,        OCGT__(small__GT),  2025,  400,                  32000000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values(["region_id", "technology"]).reset_index(drop=True),
+        expected.sort_values(["region_id", "technology"]).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def test_canonicalise_non_vre_technologies_unmatched_raises(csv_str_to_df):
+    # A technology that can't be fuzzy-matched to any canonical name raises.
+    # Pins the (deferred) behaviour for only-VRE / inconsistent inputs — see the
+    # NOTE in _canonicalise_non_vre_technologies.
+    df = csv_str_to_df("""
+        region_id,  technology,  year,  connection_capacity,  connection_cost
+        NSW,        CCGT,        2025,  400,                  40000000.0
+    """)
+    canonical_technologies = {"Wind", "Large scale Solar PV"}
+
+    with pytest.raises(ValueError, match="Could not fuzzy match"):
+        _canonicalise_non_vre_technologies(df, canonical_technologies)
+
+
+def test_canonicalise_non_vre_technologies_empty_canonical_set_returns_empty(
+    csv_str_to_df,
+):
+    # Brownfield: no new-entrant non-VRE technologies → empty output, no raise.
+    df = csv_str_to_df("""
+        region_id,  technology,  year,  connection_capacity,  connection_cost
+        NSW,        CCGT,        2025,  400,                  40000000.0
+    """)
+
+    result = _canonicalise_non_vre_technologies(df, set())
+
+    expected = csv_str_to_df("""
+        region_id,  technology,  year,  connection_capacity,  connection_cost
+    """)
+    pd.testing.assert_frame_equal(
+        result.reset_index(drop=True),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+# --- _create_non_vre_rez_cost_rows ---
+
+
+def test_create_non_vre_rez_cost_rows(csv_str_to_df):
+    # Only non-VRE technologies sited in REZs are returned, with parent region.
+    # S1 Battery (REZ, non-VRE) kept, inherits parent region (SA) cost;
+    # S1 CCGT (REZ, non-VRE) not in connection_costs -> excluded;
+    # S1 Wind (REZ but VRE) excluded; CSA Battery and NQ CCGT (non-VRE but
+    # subregions, not REZs) excluded; NQ Wind (VRE, not REZ) excluded.
+    canon_tech_geo_id_pairs = csv_str_to_df("""
+        geo_id,     technology
+        S1,         Battery__Storage__(4h)
+        S1,         CCGT
+        S1,         Wind
+        CSA,        Battery__Storage__(4h)
+        NQ,         CCGT
+        NQ,         Wind
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        S1,         rez,            SA
+        CSA,        subregion,      SA
+        NQ,         subregion,      QLD
+    """)
+    connection_costs = csv_str_to_df("""
+        region_id,  technology,             year,   connection_cost
+        SA,         Battery__Storage__(4h), 2025,   90000.0
+        SA,         Battery__Storage__(4h), 2026,   95000.0
+        QLD,        CCGT,                   2025,   100000.0
+        QLD,        CCGT,                   2026,   110000.0
+    """)
+
+    result = _create_non_vre_rez_cost_rows(
+        canon_tech_geo_id_pairs, sub_regional_geography, connection_costs
+    )
+
+    expected = csv_str_to_df("""
+        geo_id,     technology,             year,   connection_cost
+        S1,         Battery__Storage__(4h), 2025,   90000.0
+        S1,         Battery__Storage__(4h), 2026,   95000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values(["geo_id", "year"]).reset_index(drop=True),
+        expected.sort_values(["geo_id", "year"]).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+# --- _expand_non_vre_connection_costs_to_subregions ---
+
+
+def test_expand_non_vre_connection_costs_to_subregions(csv_str_to_df):
+    # Region-level costs fan out to one row per subregion; REZ rows in the
+    # geography are ignored (inner merge on subregions only).
+    non_vre_connection_costs = csv_str_to_df("""
+        region_id,  technology,         year,  connection_cost
+        QLD,        OCGT__(small__GT),  2025,  120000.0
+        QLD,        OCGT__(small__GT),  2026,  130000.0
+        NSW,        OCGT__(small__GT),  2025,  100000.0
+        NSW,        OCGT__(small__GT),  2026,  110000.0
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,  geo_type,   region_id
+        Q9,      rez,        QLD
+        NQ,      subregion,  QLD
+        CQ,      subregion,  QLD
+        NNSW,    subregion,  NSW
+    """)
+
+    result = _expand_non_vre_connection_costs_to_subregions(
+        non_vre_connection_costs, sub_regional_geography
+    )
+
+    expected = csv_str_to_df("""
+        geo_id,  technology,         year,  connection_cost
+        NQ,      OCGT__(small__GT),  2025,  120000.0
+        NQ,      OCGT__(small__GT),  2026,  130000.0
+        CQ,      OCGT__(small__GT),  2025,  120000.0
+        CQ,      OCGT__(small__GT),  2026,  130000.0
+        NNSW,    OCGT__(small__GT),  2025,  100000.0
+        NNSW,    OCGT__(small__GT),  2026,  110000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values("geo_id").reset_index(drop=True),
+        expected.sort_values("geo_id").reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+# --- _average_connection_costs_across_regions ---
+
+
+def test_average_connection_costs_across_regions(csv_str_to_df):
+    # Costs averaged across regions per (technology, year); geo_id set to "NEM".
+    non_vre_connection_costs = csv_str_to_df("""
+        region_id,  technology,         year,  connection_cost
+        NSW,        OCGT__(small__GT),  2025,  100000.0
+        NSW,        OCGT__(small__GT),  2026,  110000.0
+        QLD,        OCGT__(small__GT),  2025,  120000.0
+        QLD,        OCGT__(small__GT),  2026,  130000.0
+        VIC,        OCGT__(small__GT),  2025,  80000.0
+        VIC,        OCGT__(small__GT),  2026,  90000.0
+    """)
+
+    result = _average_connection_costs_across_regions(non_vre_connection_costs)
+
+    expected = csv_str_to_df("""
+        geo_id,  technology,         year,  connection_cost
+        NEM,     OCGT__(small__GT),  2025,  100000.0
+        NEM,     OCGT__(small__GT),  2026,  110000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.reset_index(drop=True),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+# --- _filter_connection_costs_by_regional_granularity ---
+
+
+def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
+    # All three branches share inputs; each appends the REZ-battery row (N1,
+    # inheriting the NSW cost). Asserted per branch below.
+    non_vre_connection_costs = csv_str_to_df("""
+        region_id,  technology,              year,  connection_cost
+        NSW,        CCGT,                    2025,  100000.0
+        NSW,        Battery__Storage__(4h),  2025,  50000.0
+        QLD,        CCGT,                    2025,  120000.0
+        QLD,        Battery__Storage__(4h),  2025,  60000.0
+    """)
+    canon_tech_geo_id_pairs = csv_str_to_df("""
+        geo_id,  technology
+        N1,      Battery__Storage__(4h)
+        SNW,     Battery__Storage__(4h)
+        SNW,     CCGT
+        CQ,      Battery__Storage__(4h)
+        CQ,      CCGT
+        NQ,      Battery__Storage__(4h)
+        NQ,      CCGT
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,  geo_type,   region_id
+        N1,      rez,        NSW
+        SNW,     subregion,  NSW
+        CQ,      subregion,  QLD
+        NQ,      subregion,  QLD
+    """)
+
+    sort_cols = ["geo_id", "technology"]
+
+    # nem_regions: region_id renamed to geo_id; REZ row appended.
+    result_nem = _filter_connection_costs_by_regional_granularity(
+        non_vre_connection_costs,
+        "nem_regions",
+        canon_tech_geo_id_pairs,
+        sub_regional_geography,
+    )
+    expected_nem = csv_str_to_df("""
+        geo_id,  technology,              year,  connection_cost
+        NSW,     CCGT,                    2025,  100000.0
+        NSW,     Battery__Storage__(4h),  2025,  50000.0
+        QLD,     CCGT,                    2025,  120000.0
+        QLD,     Battery__Storage__(4h),  2025,  60000.0
+        N1,      Battery__Storage__(4h),  2025,  50000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result_nem.sort_values(sort_cols).reset_index(drop=True),
+        expected_nem.sort_values(sort_cols).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+    # sub_regions: costs expanded to each subregion; REZ row appended.
+    result_sub = _filter_connection_costs_by_regional_granularity(
+        non_vre_connection_costs,
+        "sub_regions",
+        canon_tech_geo_id_pairs,
+        sub_regional_geography,
+    )
+    expected_sub = csv_str_to_df("""
+        geo_id,  technology,              year,  connection_cost
+        SNW,     CCGT,                    2025,  100000.0
+        SNW,     Battery__Storage__(4h),  2025,  50000.0
+        CQ,      CCGT,                    2025,  120000.0
+        CQ,      Battery__Storage__(4h),  2025,  60000.0
+        NQ,      CCGT,                    2025,  120000.0
+        NQ,      Battery__Storage__(4h),  2025,  60000.0
+        N1,      Battery__Storage__(4h),  2025,  50000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result_sub.sort_values(sort_cols).reset_index(drop=True),
+        expected_sub.sort_values(sort_cols).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+    # single_region: costs averaged to one "NEM" geo_id; REZ row keeps NSW cost.
+    result_single = _filter_connection_costs_by_regional_granularity(
+        non_vre_connection_costs,
+        "single_region",
+        canon_tech_geo_id_pairs,
+        sub_regional_geography,
+    )
+    expected_single = csv_str_to_df("""
+        geo_id,  technology,              year,  connection_cost
+        NEM,     CCGT,                    2025,  110000.0
+        NEM,     Battery__Storage__(4h),  2025,  55000.0
+        N1,      Battery__Storage__(4h),  2025,  50000.0
+    """)
+    pd.testing.assert_frame_equal(
+        result_single.sort_values(sort_cols).reset_index(drop=True),
+        expected_single.sort_values(sort_cols).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def test_filter_connection_costs_by_regional_granularity_invalid_raises(csv_str_to_df):
+    non_vre_connection_costs = csv_str_to_df("""
+        region_id,  technology,  year,  connection_cost
+        NSW,        CCGT,        2025,  100000.0
+    """)
+    canon_tech_geo_id_pairs = csv_str_to_df("""
+        geo_id,  technology
+        SNW,     CCGT
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,  geo_type,   region_id
+        SNW,     subregion,  NSW
+    """)
+
+    with pytest.raises(ValueError, match="Unknown regional_granularity"):
+        _filter_connection_costs_by_regional_granularity(
+            non_vre_connection_costs,
+            "various_swamps",
+            canon_tech_geo_id_pairs,
+            sub_regional_geography,
+        )
+
+
+# --- _template_non_vre_connection_costs (integration) ---
+# Wiring test only — detailed content covered by the unit tests above.
+
+
+def test_template_non_vre_connection_costs(csv_str_to_df):
+    connection_cost_forecast_other = csv_str_to_df("""
+        Generator__Type,        Region,     Scenario,       2024-25
+        CCGT,                   NSW,        Step__Change,   40000000
+        Battery__Storage__(4h), NSW,        Step__Change,   20000000
+        CCGT,                   QLD,        Step__Change,   40000000
+        Battery__Storage__(4h), QLD,        Step__Change,   20000000
+    """)
+    connection_capacity_df = csv_str_to_df("""
+        Region,     Generator__Type,        Connection__capacity__(MVA)
+        NSW,        CCGT,                   400
+        NSW,        Battery__Storage__(4h), 400
+        QLD,        CCGT,                   300
+        QLD,        Battery__Storage__(4h), 300
+    """)
+    canon_tech_geo_id_pairs = csv_str_to_df("""
+        geo_id,     technology
+        SQ,         CCGT
+        SQ,         Battery__Storage__(4h)
+        CNSW,       CCGT
+        CNSW,       Battery__Storage__(4h)
+        SNW,        CCGT
+        SNW,        Battery__Storage__(4h)
+        N1,         Battery__Storage__(4h)
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,   region_id
+        SQ,         subregion,  QLD
+        CNSW,       subregion,  NSW
+        SNW,        subregion,  NSW
+        N1,         rez,        NSW
+    """)
+
+    result_subregions = _template_non_vre_connection_costs(
+        connection_cost_forecast_other,
+        connection_capacity_df,
+        "Step Change",
+        canon_tech_geo_id_pairs,
+        "sub_regions",
+        sub_regional_geography,
+    )
+
+    # 6 subregion rows: (CCGT, Battery) x (CNSW, SNW, SQ) + 1 REZ-battery append (N1) = 7
+    assert list(result_subregions.columns) == _CONNECTION_ONLY_COST_COLS
+    assert len(result_subregions) == 7
+
+    result_nem_regions = _template_non_vre_connection_costs(
+        connection_cost_forecast_other,
+        connection_capacity_df,
+        "Step Change",
+        canon_tech_geo_id_pairs,
+        "nem_regions",
+        sub_regional_geography,
+    )
+
+    # 4 NEM region rows (Battery, CCGT) x (NSW, QLD) + 1 REZ-battery append (N1) = 5
+    assert list(result_nem_regions.columns) == _CONNECTION_ONLY_COST_COLS
+    assert len(result_nem_regions) == 5
+
+    result_single_region = _template_non_vre_connection_costs(
+        connection_cost_forecast_other,
+        connection_capacity_df,
+        "Step Change",
+        canon_tech_geo_id_pairs,
+        "single_region",
+        sub_regional_geography,
+    )
+
+    # 2 NEM rows (CCGT, Battery) + 1 REZ-battery append (N1) = 3.
+    assert list(result_single_region.columns) == _CONNECTION_ONLY_COST_COLS
+    assert len(result_single_region) == 3
+
+
 # --- _template_connection_costs (integration) ---
 # Wiring test only — detailed content covered by unit tests above.
 
 
 def test_template_connection_costs(csv_str_to_df):
-    connection_cost_forecast_vre = csv_str_to_df("""
-        REZ__ID,  Scenario,     2024-25
-        N1,       Step__Change, 73000000
-    """)
-    connection_costs_for_vre = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
-        N1,       400
-    """)
-    system_strength_cost_table = csv_str_to_df("""
-        label,  2024-25
-        IBR,    10
-    """)
+    # Wiring test: exercises the VRE path, the non-VRE region-expansion path, and
+    # the REZ-battery append path together. Detailed content is covered by the
+    # per-helper unit tests above, so we assert column set + row count only.
+    iasr_tables = {
+        "connection_cost_forecast_wind_and_solar": csv_str_to_df("""
+            REZ__ID,  Scenario,      2024-25
+            N1,       Step__Change,  73000000
+        """),
+        "connection_costs_for_wind_and_solar": csv_str_to_df("""
+            REZ__ID,  Connection__capacity__(MVA)
+            N1,       400
+        """),
+        "connection_cost_forecast_other": csv_str_to_df("""
+            Generator__Type,         Region,  Scenario,      2024-25
+            CCGT,                    NSW,     Step__Change,  40000000
+            Battery__Storage__(4h),  NSW,     Step__Change,  20000000
+        """),
+        "connection_capacity_non_vre": csv_str_to_df("""
+            Region,  Generator__Type,         Connection__capacity__(MVA)
+            NSW,     CCGT,                    400
+            NSW,     Battery__Storage__(4h),  400
+        """),
+        "efficient_level_of_system_strength_cost": csv_str_to_df("""
+            label,  2024-25
+            IBR,    10
+        """),
+    }
     generators_new_entrant = csv_str_to_df("""
         geo_id,  technology
         N1,      Wind
+        CNSW,    CCGT
+    """)
+    storage_new_entrant = csv_str_to_df("""
+        geo_id,  technology
+        CNSW,    Battery__Storage__(4h)
+        N1,      Battery__Storage__(4h)
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,  geo_type,   region_id
+        CNSW,    subregion,  NSW
+        N1,      rez,        NSW
     """)
 
     result = _template_connection_costs(
-        connection_cost_forecast_vre,
-        connection_costs_for_vre,
-        system_strength_cost_table,
+        iasr_tables,
         "Step Change",
+        "sub_regions",
         generators_new_entrant,
+        storage_new_entrant,
+        sub_regional_geography,
     )
 
+    # 1 VRE (N1 Wind) + 2 non-VRE subregion (CNSW CCGT, CNSW Battery)
+    # + 1 REZ-battery append (N1 Battery, inheriting the NSW cost) = 4 rows.
     assert list(result.columns) == _CONNECTION_SYSTEM_STRENGTH_COST_COLS
-    assert len(result) == 1  # one (geo_id, technology, year) combination
+    assert len(result) == 4
 
 
 def test_template_connection_costs_empty_inputs_give_empty_output(csv_str_to_df):
     # All empty inputs → empty output with all expected columns present.
-    connection_cost_forecast_vre = csv_str_to_df("""
-        REZ__ID,  Scenario,     2024-25
-    """)
-    connection_costs_for_vre = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
-    """)
-    system_strength_cost_table = csv_str_to_df("""
-        label,  2024-25
-    """)
-    generators_new_entrant = csv_str_to_df("""
-        geo_id,  technology
-    """)
+    iasr_tables = {
+        "connection_cost_forecast_wind_and_solar": csv_str_to_df("""
+            REZ__ID,  Scenario,  2024-25
+        """),
+        "connection_costs_for_wind_and_solar": csv_str_to_df("""
+            REZ__ID,  Connection__capacity__(MVA)
+        """),
+        "connection_cost_forecast_other": csv_str_to_df("""
+            Generator__Type,  Region,  Scenario,  2024-25
+        """),
+        "connection_capacity_non_vre": csv_str_to_df("""
+            Region,  Generator__Type,  Connection__capacity__(MVA)
+        """),
+        "efficient_level_of_system_strength_cost": csv_str_to_df("""
+            label,  2024-25
+        """),
+    }
 
     result = _template_connection_costs(
-        connection_cost_forecast_vre,
-        connection_costs_for_vre,
-        system_strength_cost_table,
+        iasr_tables,
         "Step Change",
-        generators_new_entrant,
+        "sub_regions",
+        pd.DataFrame(columns=_GEO_TECH_COLS),
+        pd.DataFrame(columns=_GEO_TECH_COLS),
+        pd.DataFrame(columns=["geo_id", "geo_type", "region_id"]),
     )
 
     assert list(result.columns) == _CONNECTION_SYSTEM_STRENGTH_COST_COLS

--- a/tests/test_templater/test_connection_and_build_costs.py
+++ b/tests/test_templater/test_connection_and_build_costs.py
@@ -16,7 +16,6 @@ from ispypsa.templater.connection_and_build_costs import (
     _get_canon_technology_and_geo_id_pairs,
     _get_unique_vre_geo_id_rows,
     _merge_and_filter_system_strength_costs,
-    _merge_connection_cost_and_capacity_frames,
     _normalise_connection_cost_forecast_frame,
     _normalise_system_strength_cost_frame,
     _set_non_ibr_system_strength_cost_to_zero,
@@ -130,7 +129,7 @@ def test_enforce_numeric_cols(csv_str_to_df):
 
 
 def test_normalise_connection_cost_forecast_frame(csv_str_to_df):
-    # Wide-to-long reshape, FY string → int year, extra columns dropped (REZ names).
+    # Wide-to-long reshape, FY string -> int year, extra columns dropped (REZ names).
     connection_cost_forecast = csv_str_to_df("""
         REZ__ID, REZ__names,        Connection__capacity__(MVA), 2024-25,     2025-26
         N1,      North__West__NSW,  400,                         730000000,   740000000
@@ -230,96 +229,6 @@ def test_normalise_connection_cost_forecast_frame_empty_input(csv_str_to_df):
     )
 
 
-# --- _merge_connection_cost_and_capacity_frames ---
-
-
-def test_merge_connection_cost_and_capacity_frames(csv_str_to_df):
-    # Left join on cost_df: cost rows with matching capacity are merged,
-    # cost row with no capacity (R99) gets NaN connection_capacity,
-    # capacity-only row (N0) is dropped. (T4) with NaN values but present in
-    # both is retained.
-    cost_df = csv_str_to_df("""
-        REZ__ID,  2024-25
-        N1,       73000000
-        Q9,       854000000
-        R99,      120000000
-        T4,
-    """)
-    capacity_df = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
-        N1,       400
-        Q9,       1800
-        N0,       200
-        T4,
-    """)
-
-    result = _merge_connection_cost_and_capacity_frames(
-        cost_df, capacity_df, ["REZ ID"]
-    )
-
-    expected = csv_str_to_df("""
-        REZ__ID,  2024-25,     Connection__capacity__(MVA)
-        N1,       73000000,    400
-        Q9,       854000000,   1800
-        R99,      120000000,
-        T4,       ,
-    """)
-    pd.testing.assert_frame_equal(
-        result.sort_values("REZ ID").reset_index(drop=True),
-        expected.sort_values("REZ ID").reset_index(drop=True),
-        check_dtype=False,
-    )
-
-
-def test_merge_connection_cost_and_capacity_frames_empty_inputs(csv_str_to_df):
-    # Empty cost_df → empty output (left join produces no rows).
-    # Empty capacity_df → cost rows survive with NaN capacity (left join).
-    empty_cost_df = csv_str_to_df("""
-        REZ__ID,  2024-25
-    """)
-    capacity_df = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
-        N1,       400
-    """)
-
-    result_empty_cost = _merge_connection_cost_and_capacity_frames(
-        empty_cost_df,
-        capacity_df,
-        ["REZ ID"],
-    )
-    expected_empty_cost = csv_str_to_df("""
-    REZ__ID,  2024-25,  Connection__capacity__(MVA)
-    """)
-    pd.testing.assert_frame_equal(
-        result_empty_cost.sort_values("REZ ID").reset_index(drop=True),
-        expected_empty_cost.sort_values("REZ ID").reset_index(drop=True),
-        check_dtype=False,
-    )
-
-    cost_df = csv_str_to_df("""
-        REZ__ID,    2024-25
-        N1,         73000000
-    """)
-    empty_capacity_df = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
-    """)
-
-    result_empty_capacity = _merge_connection_cost_and_capacity_frames(
-        cost_df,
-        empty_capacity_df,
-        ["REZ ID"],
-    )
-    expected_nan_capacity = csv_str_to_df("""
-        REZ__ID,  2024-25,   Connection__capacity__(MVA)
-        N1,       73000000,
-    """)
-    pd.testing.assert_frame_equal(
-        result_empty_capacity.reset_index(drop=True),
-        expected_nan_capacity.reset_index(drop=True),
-        check_dtype=False,
-    )
-
-
 # --- _calculate_connection_cost_per_mw ---
 
 
@@ -351,7 +260,7 @@ def test_calculate_connection_cost_per_mw(csv_str_to_df):
 
 
 def test_calculate_connection_cost_per_mw_zero_capacity_gives_na(csv_str_to_df):
-    # Division by zero produces inf, which is replaced with pd.NA → NaN.
+    # Division by zero produces inf, which is replaced with pd.NA -> NaN.
     # Division by NaN results NaN.
     cost_and_capacity_df = csv_str_to_df("""
         geo_id,     connection_capacity,  year,     connection_cost
@@ -417,7 +326,7 @@ def test_warn_nan_connection_costs_no_warning_when_all_costs_valid(
 
 
 def test_normalise_system_strength_cost_frame(csv_str_to_df):
-    # Wide single-row table → long (year, system_strength_cost).
+    # Wide single-row table -> long (year, system_strength_cost).
     # $/kW * 1000 = $/MW conversion applied.
     # FY strings converted to year int, long-form year string fix applied correctly.
     # Non-year label column dropped.
@@ -567,7 +476,7 @@ def test_merge_and_filter_system_strength_costs(csv_str_to_df):
 def test_merge_and_filter_system_strength_costs_year_not_in_system_strength_gives_nan(
     csv_str_to_df,
 ):
-    # Year in connection_costs but absent from system_strength_costs → NaN
+    # Year in connection_costs but absent from system_strength_costs -> NaN
     connection_costs = csv_str_to_df("""
         geo_id,  technology,  year,  connection_cost
         N1,      Wind,        2025,  182500.0
@@ -597,7 +506,7 @@ def test_merge_and_filter_system_strength_costs_year_not_in_system_strength_give
 
 
 def test_merge_and_filter_system_strength_costs_empty_inputs(csv_str_to_df):
-    # Empty connection_costs → empty output with correct columns.
+    # Empty connection_costs -> empty output with correct columns.
     system_strength_costs = csv_str_to_df("""
         year,  system_strength_cost
         2025,  10000.0
@@ -614,7 +523,7 @@ def test_merge_and_filter_system_strength_costs_empty_inputs(csv_str_to_df):
         check_dtype=False,
     )
 
-    # Empty system_strength_costs → all system_strength_cost values are NaN.
+    # Empty system_strength_costs -> all system_strength_cost values are NaN.
     empty_system_strength_costs = csv_str_to_df("""
         year,  system_strength_cost
     """)
@@ -726,8 +635,8 @@ def test_build_vre_cost_rows(csv_str_to_df):
 
 
 def test_build_vre_cost_rows_empty_inputs(csv_str_to_df):
-    # Empty vre_technologies → no (tech, year) combinations → empty output.
-    # Empty costs_per_mw → no years to cross-join → empty output.
+    # Empty vre_technologies -> no (tech, year) combinations -> empty output.
+    # Empty costs_per_mw -> no years to cross-join -> empty output.
     costs_per_mw = csv_str_to_df("""
         geo_id,  year,  connection_cost
         N1,      2025,  182500.0
@@ -774,31 +683,38 @@ def test_build_vre_cost_rows_empty_inputs(csv_str_to_df):
 # tests); NaN warning log (covered by _warn_nan_connection_costs tests).
 
 
-def test_template_vre_connection_costs(csv_str_to_df):
+def test_template_vre_connection_costs(csv_str_to_df, caplog):
     connection_cost_forecast_vre = csv_str_to_df("""
         REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
         N1,       North__West__NSW, Step__Change, 73000000,   74000000
         Q9,       Banana,           Step__Change, 854000000,  867000000
     """)
     connection_costs_for_vre = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
-        N1,       400
-        Q9,       1800
+        REZ__ID,    Connection__capacity__(MVA)
+        N1,         400
+        Q9,         1800
+        V8,
     """)
-    vre_technologies_by_geo_id = csv_str_to_df("""
-        geo_id,  technology
-        N1,      Wind
-        N1,      Large__scale__Solar__PV
-        Q9,      Large__scale__Solar__PV
-        V8,      Wind__-__offshore__(fixed)
+    canonical_technology_geo_id_pairs = csv_str_to_df("""
+        geo_id,     technology
+        N1,         Wind
+        N1,         Large__scale__Solar__PV
+        Q9,         Large__scale__Solar__PV
+        V8,         Wind__-__offshore__(fixed)
+        NNSW,       CCGT
+        SQ,         Pumped__Hydro
     """)
 
-    result = _template_vre_connection_costs(
-        connection_cost_forecast_vre,
-        connection_costs_for_vre,
-        "Step Change",
-        vre_technologies_by_geo_id,
-    )
+    with caplog.at_level("WARNING"):
+        result = _template_vre_connection_costs(
+            connection_cost_forecast_vre,
+            connection_costs_for_vre,
+            "Step Change",
+            canonical_technology_geo_id_pairs,
+        )
+
+    # No warning raised for offshore REZ NaN cost (row added after NaNs checked)
+    assert "NaN connection cost" not in caplog.text
 
     # Columns correct; 3 (geo_id, tech) pairs × 2 years + 2 offshore NaN rows = 8
     assert list(result.columns) == _CONNECTION_ONLY_COST_COLS
@@ -868,7 +784,7 @@ def test_template_vre_connection_costs_some_empty_inputs(csv_str_to_df):
 
 
 def test_template_vre_connection_costs_empty_capacity_gives_nan_costs(csv_str_to_df):
-    # Non-empty forecast and technologies but empty capacity → NaN connection_cost
+    # Non-empty forecast and technologies but empty capacity -> NaN connection_cost
     connection_cost_forecast_vre = csv_str_to_df("""
         REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
         N1,       North__West__NSW, Step__Change, 73000000,   74000000
@@ -906,7 +822,6 @@ def test_template_vre_connection_costs_empty_capacity_gives_nan_costs(csv_str_to
 
 def test_get_canon_technology_and_geo_id_pairs(csv_str_to_df):
     # Union of generator and storage (geo_id, technology) pairs, deduplicated.
-    # (CNSW, CCGT) appears in both tables and as a within-table duplicate → one row.
     generators_new_entrant = csv_str_to_df("""
         geo_id,  technology
         N1,      Wind
@@ -916,7 +831,6 @@ def test_get_canon_technology_and_geo_id_pairs(csv_str_to_df):
     storage_new_entrant = csv_str_to_df("""
         geo_id,  technology
         CNSW,    Battery__Storage__(4h)
-        CNSW,    CCGT
     """)
 
     result = _get_canon_technology_and_geo_id_pairs(
@@ -979,7 +893,7 @@ def test_canonicalise_non_vre_technologies_unmatched_raises(csv_str_to_df):
 def test_canonicalise_non_vre_technologies_empty_canonical_set_returns_empty(
     csv_str_to_df,
 ):
-    # Brownfield: no new-entrant non-VRE technologies → empty output, no raise.
+    # Brownfield: no new-entrant non-VRE technologies -> empty output, no raise.
     df = csv_str_to_df("""
         region_id,  technology,  year,  connection_capacity,  connection_cost
         NSW,        CCGT,        2025,  400,                  40000000.0
@@ -1028,11 +942,9 @@ def test_create_non_vre_rez_cost_rows(csv_str_to_df):
         QLD,        CCGT,                   2025,   100000.0
         QLD,        CCGT,                   2026,   110000.0
     """)
-
     result = _create_non_vre_rez_cost_rows(
         canon_tech_geo_id_pairs, sub_regional_geography, connection_costs
     )
-
     expected = csv_str_to_df("""
         geo_id,     technology,             year,   connection_cost
         S1,         Battery__Storage__(4h), 2025,   90000.0
@@ -1041,6 +953,59 @@ def test_create_non_vre_rez_cost_rows(csv_str_to_df):
     pd.testing.assert_frame_equal(
         result.sort_values(["geo_id", "year"]).reset_index(drop=True),
         expected.sort_values(["geo_id", "year"]).reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def test_create_non_vre_rez_cost_rows_empty_inputs(csv_str_to_df):
+    # Combinatorial empty inputs testing
+    pairs = csv_str_to_df("""
+        geo_id,     technology
+        S1,         Battery__Storage__(4h)
+    """)
+    geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        S1,         rez,            SA
+    """)
+    costs = csv_str_to_df("""
+        region_id,  technology,             year,   connection_cost
+        SA,         Battery__Storage__(4h), 2025,   90000.0
+    """)
+    empty_pairs = pd.DataFrame(columns=pairs.columns)
+    empty_geography = pd.DataFrame(columns=geography.columns)
+    empty_costs = pd.DataFrame(columns=costs.columns)
+
+    expected = pd.DataFrame(columns=_CONNECTION_ONLY_COST_COLS)
+    # A emtpy
+    pd.testing.assert_frame_equal(
+        _create_non_vre_rez_cost_rows(empty_pairs, geography, costs).reset_index(
+            drop=True
+        ),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+    # B emtpy
+    pd.testing.assert_frame_equal(
+        _create_non_vre_rez_cost_rows(pairs, empty_geography, costs).reset_index(
+            drop=True
+        ),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+    # C emtpy
+    pd.testing.assert_frame_equal(
+        _create_non_vre_rez_cost_rows(pairs, geography, empty_costs).reset_index(
+            drop=True
+        ),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+    # All emtpy
+    pd.testing.assert_frame_equal(
+        _create_non_vre_rez_cost_rows(
+            empty_pairs, empty_geography, empty_costs
+        ).reset_index(drop=True),
+        expected.reset_index(drop=True),
         check_dtype=False,
     )
 
@@ -1055,15 +1020,12 @@ def test_expand_non_vre_connection_costs_to_subregions(csv_str_to_df):
         region_id,  technology,         year,  connection_cost
         QLD,        OCGT__(small__GT),  2025,  120000.0
         QLD,        OCGT__(small__GT),  2026,  130000.0
-        NSW,        OCGT__(small__GT),  2025,  100000.0
-        NSW,        OCGT__(small__GT),  2026,  110000.0
     """)
     sub_regional_geography = csv_str_to_df("""
         geo_id,  geo_type,   region_id
         Q9,      rez,        QLD
         NQ,      subregion,  QLD
         CQ,      subregion,  QLD
-        NNSW,    subregion,  NSW
     """)
 
     result = _expand_non_vre_connection_costs_to_subregions(
@@ -1076,12 +1038,51 @@ def test_expand_non_vre_connection_costs_to_subregions(csv_str_to_df):
         NQ,      OCGT__(small__GT),  2026,  130000.0
         CQ,      OCGT__(small__GT),  2025,  120000.0
         CQ,      OCGT__(small__GT),  2026,  130000.0
-        NNSW,    OCGT__(small__GT),  2025,  100000.0
-        NNSW,    OCGT__(small__GT),  2026,  110000.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values("geo_id").reset_index(drop=True),
         expected.sort_values("geo_id").reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def test_expand_non_vre_connection_costs_to_subregions_empty_inputs(csv_str_to_df):
+    # Combinatorial empty inputs - all return empty df with columns ==
+    # ``_CONNECTION_ONLY_COST_COLS``
+    costs = csv_str_to_df("""
+        region_id,  technology,         year,  connection_cost
+        QLD,        OCGT__(small__GT),  2025,  120000.0
+    """)
+    empty_costs = pd.DataFrame(columns=costs.columns)
+    geography = csv_str_to_df("""
+        geo_id,  geo_type,   region_id
+        CQ,      subregion,  QLD
+    """)
+    empty_geo = pd.DataFrame(columns=geography.columns)
+
+    expected = pd.DataFrame(columns=_CONNECTION_ONLY_COST_COLS)
+    # A empty:
+    pd.testing.assert_frame_equal(
+        _expand_non_vre_connection_costs_to_subregions(
+            empty_costs, geography
+        ).reset_index(drop=True),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+    # B empty:
+    pd.testing.assert_frame_equal(
+        _expand_non_vre_connection_costs_to_subregions(costs, empty_geo).reset_index(
+            drop=True
+        ),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+    # Both empty:
+    pd.testing.assert_frame_equal(
+        _expand_non_vre_connection_costs_to_subregions(
+            empty_costs, empty_geo
+        ).reset_index(drop=True),
+        expected.reset_index(drop=True),
         check_dtype=False,
     )
 
@@ -1115,12 +1116,27 @@ def test_average_connection_costs_across_regions(csv_str_to_df):
     )
 
 
+def test_average_connection_costs_across_regions_empty_input(csv_str_to_df):
+    # Costs averaged across regions per (technology, year); geo_id set to "NEM".
+    non_vre_connection_costs = csv_str_to_df("""
+        region_id,  technology,         year,  connection_cost
+    """)
+    result = _average_connection_costs_across_regions(non_vre_connection_costs)
+    expected = pd.DataFrame(columns=_CONNECTION_ONLY_COST_COLS)
+    pd.testing.assert_frame_equal(
+        result.reset_index(drop=True),
+        expected.reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
 # --- _filter_connection_costs_by_regional_granularity ---
+# Wiring test only - details covered by above tests
 
 
 def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
     # All three branches share inputs; each appends the REZ-battery row (N1,
-    # inheriting the NSW cost). Asserted per branch below.
+    # inheriting the NSW cost). Asserted per branch below (wiring).
     non_vre_connection_costs = csv_str_to_df("""
         region_id,  technology,              year,  connection_cost
         NSW,        CCGT,                    2025,  100000.0
@@ -1146,8 +1162,6 @@ def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
         NQ,      subregion,  QLD
     """)
 
-    sort_cols = ["geo_id", "technology"]
-
     # nem_regions: region_id renamed to geo_id; REZ row appended.
     result_nem = _filter_connection_costs_by_regional_granularity(
         non_vre_connection_costs,
@@ -1155,19 +1169,10 @@ def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
         canon_tech_geo_id_pairs,
         sub_regional_geography,
     )
-    expected_nem = csv_str_to_df("""
-        geo_id,  technology,              year,  connection_cost
-        NSW,     CCGT,                    2025,  100000.0
-        NSW,     Battery__Storage__(4h),  2025,  50000.0
-        QLD,     CCGT,                    2025,  120000.0
-        QLD,     Battery__Storage__(4h),  2025,  60000.0
-        N1,      Battery__Storage__(4h),  2025,  50000.0
-    """)
-    pd.testing.assert_frame_equal(
-        result_nem.sort_values(sort_cols).reset_index(drop=True),
-        expected_nem.sort_values(sort_cols).reset_index(drop=True),
-        check_dtype=False,
-    )
+    # REZ row appended, columns as required, geo_ids are correct (regions + REZ)
+    assert set(result_nem.columns) == set(_CONNECTION_ONLY_COST_COLS)
+    assert len(result_nem) == 5  # (NSW, QLD) * 2 tech + 1 REZ
+    assert set(result_nem["geo_id"].values) == {"NSW", "QLD", "N1"}
 
     # sub_regions: costs expanded to each subregion; REZ row appended.
     result_sub = _filter_connection_costs_by_regional_granularity(
@@ -1176,21 +1181,9 @@ def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
         canon_tech_geo_id_pairs,
         sub_regional_geography,
     )
-    expected_sub = csv_str_to_df("""
-        geo_id,  technology,              year,  connection_cost
-        SNW,     CCGT,                    2025,  100000.0
-        SNW,     Battery__Storage__(4h),  2025,  50000.0
-        CQ,      CCGT,                    2025,  120000.0
-        CQ,      Battery__Storage__(4h),  2025,  60000.0
-        NQ,      CCGT,                    2025,  120000.0
-        NQ,      Battery__Storage__(4h),  2025,  60000.0
-        N1,      Battery__Storage__(4h),  2025,  50000.0
-    """)
-    pd.testing.assert_frame_equal(
-        result_sub.sort_values(sort_cols).reset_index(drop=True),
-        expected_sub.sort_values(sort_cols).reset_index(drop=True),
-        check_dtype=False,
-    )
+    assert set(result_sub.columns) == set(_CONNECTION_ONLY_COST_COLS)
+    assert len(result_sub) == 7  # (SNW, CQ, NQ) * 2 tech + 1 REZ
+    assert set(result_sub["geo_id"].values) == {"SNW", "CQ", "NQ", "N1"}
 
     # single_region: costs averaged to one "NEM" geo_id; REZ row keeps NSW cost.
     result_single = _filter_connection_costs_by_regional_granularity(
@@ -1199,17 +1192,9 @@ def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
         canon_tech_geo_id_pairs,
         sub_regional_geography,
     )
-    expected_single = csv_str_to_df("""
-        geo_id,  technology,              year,  connection_cost
-        NEM,     CCGT,                    2025,  110000.0
-        NEM,     Battery__Storage__(4h),  2025,  55000.0
-        N1,      Battery__Storage__(4h),  2025,  50000.0
-    """)
-    pd.testing.assert_frame_equal(
-        result_single.sort_values(sort_cols).reset_index(drop=True),
-        expected_single.sort_values(sort_cols).reset_index(drop=True),
-        check_dtype=False,
-    )
+    assert set(result_single.columns) == set(_CONNECTION_ONLY_COST_COLS)
+    assert len(result_single) == 3  # NEM * 2 tech + 1 REZ
+    assert set(result_single["geo_id"].values) == {"NEM", "N1"}
 
 
 def test_filter_connection_costs_by_regional_granularity_invalid_raises(csv_str_to_df):
@@ -1241,23 +1226,17 @@ def test_filter_connection_costs_by_regional_granularity_invalid_raises(csv_str_
 
 def test_template_non_vre_connection_costs(csv_str_to_df):
     connection_cost_forecast_other = csv_str_to_df("""
-        Generator__Type,        Region,     Scenario,       2024-25
-        CCGT,                   NSW,        Step__Change,   40000000
-        Battery__Storage__(4h), NSW,        Step__Change,   20000000
-        CCGT,                   QLD,        Step__Change,   40000000
-        Battery__Storage__(4h), QLD,        Step__Change,   20000000
+        Generator__Type,        Region,     Scenario,       2024-25,    2025-26
+        CCGT,                   NSW,        Step__Change,   40000000,   41000000
+        Battery__Storage__(4h), NSW,        Step__Change,   20000000,   22000000
     """)
     connection_capacity_df = csv_str_to_df("""
         Region,     Generator__Type,        Connection__capacity__(MVA)
         NSW,        CCGT,                   400
         NSW,        Battery__Storage__(4h), 400
-        QLD,        CCGT,                   300
-        QLD,        Battery__Storage__(4h), 300
     """)
     canon_tech_geo_id_pairs = csv_str_to_df("""
         geo_id,     technology
-        SQ,         CCGT
-        SQ,         Battery__Storage__(4h)
         CNSW,       CCGT
         CNSW,       Battery__Storage__(4h)
         SNW,        CCGT
@@ -1266,7 +1245,6 @@ def test_template_non_vre_connection_costs(csv_str_to_df):
     """)
     sub_regional_geography = csv_str_to_df("""
         geo_id,     geo_type,   region_id
-        SQ,         subregion,  QLD
         CNSW,       subregion,  NSW
         SNW,        subregion,  NSW
         N1,         rez,        NSW
@@ -1280,10 +1258,9 @@ def test_template_non_vre_connection_costs(csv_str_to_df):
         "sub_regions",
         sub_regional_geography,
     )
-
-    # 6 subregion rows: (CCGT, Battery) x (CNSW, SNW, SQ) + 1 REZ-battery append (N1) = 7
-    assert list(result_subregions.columns) == _CONNECTION_ONLY_COST_COLS
-    assert len(result_subregions) == 7
+    # (tech=(CCGT, Battery) * subregion=(CNSW, SNW) + (REZ batt)) * 2 years = 10
+    assert set(result_subregions.columns) == set(_CONNECTION_ONLY_COST_COLS)
+    assert len(result_subregions) == 10
 
     result_nem_regions = _template_non_vre_connection_costs(
         connection_cost_forecast_other,
@@ -1294,9 +1271,9 @@ def test_template_non_vre_connection_costs(csv_str_to_df):
         sub_regional_geography,
     )
 
-    # 4 NEM region rows (Battery, CCGT) x (NSW, QLD) + 1 REZ-battery append (N1) = 5
-    assert list(result_nem_regions.columns) == _CONNECTION_ONLY_COST_COLS
-    assert len(result_nem_regions) == 5
+    # (tech=(CCGT, Battery) * region=(NSW) + (REZ batt)) * 2 years = 6
+    assert set(result_nem_regions.columns) == set(_CONNECTION_ONLY_COST_COLS)
+    assert len(result_nem_regions) == 6
 
     result_single_region = _template_non_vre_connection_costs(
         connection_cost_forecast_other,
@@ -1307,9 +1284,76 @@ def test_template_non_vre_connection_costs(csv_str_to_df):
         sub_regional_geography,
     )
 
-    # 2 NEM rows (CCGT, Battery) + 1 REZ-battery append (N1) = 3.
-    assert list(result_single_region.columns) == _CONNECTION_ONLY_COST_COLS
-    assert len(result_single_region) == 3
+    # (2 NEM rows (CCGT, Battery) + REZ batt) * 2 years = 6
+    assert set(result_nem_regions.columns) == set(_CONNECTION_ONLY_COST_COLS)
+    assert len(result_single_region) == 6
+
+
+def test_template_non_vre_connection_costs_empty_inputs(csv_str_to_df):
+    # Some checks that should return an empty df with ``_CONNECTION_ONLY_COST_COLS``.
+    forecast = csv_str_to_df("""
+        Generator__Type,        Region,     Scenario,       2024-25,    2025-26
+        CCGT,                   NSW,        Step__Change,   40000000,   41000000
+    """)
+    capacity = csv_str_to_df("""
+        Region,     Generator__Type,        Connection__capacity__(MVA)
+        NSW,        CCGT,                   400
+    """)
+    # all empty inputs
+    result_all_empty = _template_non_vre_connection_costs(
+        pd.DataFrame(columns=forecast.columns),
+        pd.DataFrame(columns=capacity.columns),
+        "Step Change",
+        pd.DataFrame(columns=_GEO_TECH_COLS),
+        "single_region",
+        pd.DataFrame(columns=["geo_id", "geo_type", "region_id"]),
+    )
+    assert list(result_all_empty.columns) == _CONNECTION_ONLY_COST_COLS
+    assert result_all_empty.empty
+    # emtpy tech/geography inputs:
+    result_some_empty = _template_non_vre_connection_costs(
+        forecast,
+        capacity,
+        "Step Change",
+        pd.DataFrame(columns=_GEO_TECH_COLS),
+        "single_region",
+        pd.DataFrame(columns=["geo_id", "geo_type", "region_id"]),
+    )
+    assert list(result_some_empty.columns) == _CONNECTION_ONLY_COST_COLS
+    assert result_some_empty.empty
+
+
+def test_template_non_vre_connection_costs_empty_capacity_gives_nan_costs(
+    csv_str_to_df,
+):
+    # Non-empty forecast, technologies and geography but empty capacity
+    # -> present but NaN connection_cost
+    forecast = csv_str_to_df("""
+        Generator__Type,        Region,     Scenario,       2024-25,    2025-26
+        CCGT,                   NSW,        Step__Change,   40000000,   41000000
+    """)
+    empty_capacity = pd.DataFrame(
+        columns=["Region", "Generator Type", "Connection capacity (MVA)"]
+    )
+    pairs = csv_str_to_df("""
+        geo_id,     technology
+        CNSW,       CCGT
+    """)
+    geography = csv_str_to_df("""
+        geo_id,     geo_type,   region_id
+        CNSW,       subregion,  NSW
+    """)
+    result_nans = _template_non_vre_connection_costs(
+        forecast,
+        empty_capacity,
+        "Step Change",
+        pairs,
+        "sub_regions",
+        geography,
+    )
+    assert list(result_nans.columns) == _CONNECTION_ONLY_COST_COLS
+    assert len(result_nans) == 2  # 2 years, 1 tech, 1 subregion
+    assert all(result_nans["connection_cost"].isna())
 
 
 # --- _template_connection_costs (integration) ---
@@ -1376,7 +1420,7 @@ def test_template_connection_costs(csv_str_to_df):
 
 
 def test_template_connection_costs_empty_inputs_give_empty_output(csv_str_to_df):
-    # All empty inputs → empty output with all expected columns present.
+    # All empty inputs -> empty output with all expected columns present.
     iasr_tables = {
         "connection_cost_forecast_wind_and_solar": csv_str_to_df("""
             REZ__ID,  Scenario,  2024-25

--- a/tests/test_templater/test_connection_and_build_costs.py
+++ b/tests/test_templater/test_connection_and_build_costs.py
@@ -45,18 +45,18 @@ def test_filter_table_by_isp_scenario(csv_str_to_df):
     # NaN values in non-Scenario columns are preserved. Fuzzy matching
     # applied correctly so small typos are fixed before filtering.
     table = csv_str_to_df("""
-        Scenario,       REZ__ID,    value
-        Step__Change,   N1,         100
-        step__change,   N2,         150
-        Step__Change,   N3,
-        Stop__Change,   N4,         175
-        Slower__Growth, N1,         200
+        Scenario,       REZ ID,    value
+        Step Change,   N1,         100
+        step change,   N2,         150
+        Step Change,   N3,
+        Stop Change,   N4,         175
+        Slower Growth, N1,         200
     """)
 
     result = _filter_table_by_isp_scenario(table, "Step Change", "Scenario", "test")
 
     expected = csv_str_to_df("""
-        REZ__ID,    value
+        REZ ID,    value
         N1,         100
         N2,         150
         N3,
@@ -72,9 +72,9 @@ def test_filter_table_by_isp_scenario_no_matching_rows(csv_str_to_df, caplog):
     # No rows have matching "Scenario" values - return empty df with non-'scenario'
     # columns.
     table = csv_str_to_df("""
-        Scenario,       REZ__ID,    value
-        Step__Change,   N1,         100
-        Slower__Growth, N1,         200
+        Scenario,       REZ ID,    value
+        Step Change,    N1,         100
+        Slower Growth,  N1,         200
     """)
 
     with caplog.at_level("WARNING"):
@@ -83,7 +83,7 @@ def test_filter_table_by_isp_scenario_no_matching_rows(csv_str_to_df, caplog):
         )
 
     expected = csv_str_to_df("""
-        REZ__ID,    value
+        REZ ID,    value
     """)
     pd.testing.assert_frame_equal(
         result.reset_index(drop=True),
@@ -131,9 +131,9 @@ def test_enforce_numeric_cols(csv_str_to_df):
 def test_normalise_connection_cost_forecast_frame(csv_str_to_df):
     # Wide-to-long reshape, FY string -> int year, extra columns dropped (REZ names).
     connection_cost_forecast = csv_str_to_df("""
-        REZ__ID, REZ__names,        Connection__capacity__(MVA), 2024-25,     2025-26
-        N1,      North__West__NSW,  400,                         730000000,   740000000
-        Q9,      Banana,            1800,                        8540000000,  8670000000
+        REZ ID, REZ names,        Connection capacity (MVA), 2024-25,     2025-26
+        N1,      North West NSW,  400,                         730000000,   740000000
+        Q9,      Banana,          1800,                        8540000000,  8670000000
     """)
 
     result = _normalise_connection_cost_forecast_frame(
@@ -160,9 +160,9 @@ def test_normalise_connection_cost_forecast_frame_non_vre_renames(csv_str_to_df)
     # Non-VRE path melts with a 3-key rename dict (Region, Generator Type,
     # capacity) — a different, multi-id-column shape from the VRE case above.
     connection_cost_forecast = csv_str_to_df("""
-        Region,  Generator__Type,  Connection__capacity__(MVA),  2024-25,   2025-26
-        NSW,     CCGT,             400,                          40000000,  42000000
-        QLD,     CCGT,             300,                          36000000,  37000000
+        Region,  Generator Type,  Connection capacity (MVA),  2024-25,   2025-26
+        NSW,     CCGT,            400,                          40000000,  42000000
+        QLD,     CCGT,            300,                          36000000,  37000000
     """)
 
     result = _normalise_connection_cost_forecast_frame(
@@ -188,9 +188,9 @@ def test_normalise_connection_cost_forecast_frame_non_vre_renames(csv_str_to_df)
 def test_normalise_connection_cost_forecast_frame_preserves_nan_rows(csv_str_to_df):
     # Rows with blank/empty cost values are retained with NaN rather than dropped.
     connection_cost_forecast = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA),  2024-25
-        DN1,      150,
-        Q1,       ,                             160000000.0
+        REZ ID,  Connection capacity (MVA),  2024-25
+        DN1,     150,
+        Q1,      ,                           160000000.0
     """)
 
     result = _normalise_connection_cost_forecast_frame(
@@ -211,7 +211,7 @@ def test_normalise_connection_cost_forecast_frame_preserves_nan_rows(csv_str_to_
 
 def test_normalise_connection_cost_forecast_frame_empty_input(csv_str_to_df):
     connection_cost_forecast = csv_str_to_df("""
-        REZ__ID, REZ__names,        Connection__capacity__(MVA), 2024-25,     2025-26
+        REZ ID, REZ names,        Connection capacity (MVA), 2024-25,     2025-26
     """)
 
     result = _normalise_connection_cost_forecast_frame(
@@ -332,7 +332,7 @@ def test_normalise_system_strength_cost_frame(csv_str_to_df):
     # Non-year label column dropped.
     system_strength_cost_table = csv_str_to_df("""
         label,            2024-25,  2025-26,    2026-2027,      Notes
-        IBR__remediation, 10,       12,         15,             Some__extra__note
+        IBR remediation,  10,       12,         15,             Some extra note
     """)
 
     result = _normalise_system_strength_cost_frame(system_strength_cost_table)
@@ -379,25 +379,25 @@ def test_set_non_ibr_system_strength_cost_to_zero(csv_str_to_df):
     # This function does NOT set Solar Thermal cost to 0.0.
     # Non-IBR technologies get 0.0. Does not change any other cols.
     connection_costs = csv_str_to_df("""
-        geo_id,     year,   technology,                    connection_cost, system_strength_cost
-        S1,         2035,   Large__scale__Solar__PV,       120000.0,        10000.0
-        S1,         2035,   Wind,                          130000.0,        10000.0
-        S1,         2035,   Battery__Storage__(1hr),       140000.0,        10000.0
-        S1,         2028,   Solar__Thermal__(16hrs),       150000.0,        10000.0
-        SESA,       2035,   Small__OCGT,                   160000.0,        10000.0
-        SESA,       2035,   CCGT,                          170000.0,        10000.0
+        geo_id,     year,   technology,             connection_cost, system_strength_cost
+        S1,         2035,   Large scale Solar PV,   120000.0,        10000.0
+        S1,         2035,   Wind,                   130000.0,        10000.0
+        S1,         2035,   Battery Storage (1hr),  140000.0,        10000.0
+        S1,         2028,   Solar Thermal (16hrs),  150000.0,        10000.0
+        SESA,       2035,   Small OCGT,             160000.0,        10000.0
+        SESA,       2035,   CCGT,                   170000.0,        10000.0
     """)
 
     result = _set_non_ibr_system_strength_cost_to_zero(connection_costs)
 
     expected = csv_str_to_df("""
-        geo_id,     year,   technology,                    connection_cost, system_strength_cost
-        S1,         2035,   Large__scale__Solar__PV,       120000.0,        10000.0
-        S1,         2035,   Wind,                          130000.0,        10000.0
-        S1,         2035,   Battery__Storage__(1hr),       140000.0,        10000.0
-        S1,         2028,   Solar__Thermal__(16hrs),       150000.0,        10000.0
-        SESA,       2035,   Small__OCGT,                   160000.0,        0.0
-        SESA,       2035,   CCGT,                          170000.0,        0.0
+        geo_id,     year,   technology,             connection_cost, system_strength_cost
+        S1,         2035,   Large scale Solar PV,   120000.0,        10000.0
+        S1,         2035,   Wind,                   130000.0,        10000.0
+        S1,         2035,   Battery Storage (1hr),  140000.0,        10000.0
+        S1,         2028,   Solar Thermal (16hrs),  150000.0,        10000.0
+        SESA,       2035,   Small OCGT,             160000.0,        0.0
+        SESA,       2035,   CCGT,                   170000.0,        0.0
     """)
     pd.testing.assert_frame_equal(
         result.reset_index(drop=True),
@@ -413,17 +413,17 @@ def test_set_solar_thermal_system_strength_costs_to_zero(csv_str_to_df):
     # "Solar Thermal" is zeroed despite containing "solar".
     # Other solar technologies are unchanged.
     connection_costs = csv_str_to_df("""
-        geo_id, year,   technology,                    system_strength_cost
-        V1,     2028,   Large__scale__Solar__PV,       10000.0
-        V5,     2028,   Solar__Thermal__(16hrs),       10000.0
+        geo_id, year,   technology,                 system_strength_cost
+        V1,     2028,   Large scale Solar PV,       10000.0
+        V5,     2028,   Solar Thermal (16hrs),      10000.0
     """)
 
     result = _set_solar_thermal_system_strength_costs_to_zero(connection_costs)
 
     expected = csv_str_to_df("""
-        geo_id, year,   technology,                    system_strength_cost
-        V1,     2028,   Large__scale__Solar__PV,       10000.0
-        V5,     2028,   Solar__Thermal__(16hrs),       0.0
+        geo_id, year,   technology,                 system_strength_cost
+        V1,     2028,   Large scale Solar PV,       10000.0
+        V5,     2028,   Solar Thermal (16hrs),      0.0
     """)
     pd.testing.assert_frame_equal(
         result.reset_index(drop=True),
@@ -442,11 +442,11 @@ def test_merge_and_filter_system_strength_costs(csv_str_to_df):
     # IBR gets system strength cost, non-IBR gets 0.0, solar thermal gets 0.0.
     # Extra years present in system_strength_costs dropped in the merge.
     connection_costs = csv_str_to_df("""
-        geo_id,  technology,                year,  connection_cost
-        N1,      Large__scale__Solar__PV,   2025,  182500.0
-        N1,      Wind,                      2025,  182500.0
-        QLD,     Small__OCGT,               2025,  500000.0
-        TAS,     Solar__Thermal,            2025,  100000.0
+        geo_id,  technology,            year,  connection_cost
+        N1,      Large scale Solar PV,  2025,  182500.0
+        N1,      Wind,                  2025,  182500.0
+        QLD,     Small OCGT,            2025,  500000.0
+        TAS,     Solar Thermal,         2025,  100000.0
     """)
     system_strength_costs = csv_str_to_df("""
         year,   system_strength_cost
@@ -459,11 +459,11 @@ def test_merge_and_filter_system_strength_costs(csv_str_to_df):
     )
 
     expected = csv_str_to_df("""
-        geo_id,  technology,                year,  connection_cost,  system_strength_cost
-        N1,      Large__scale__Solar__PV,   2025,  182500.0,         10000.0
-        N1,      Wind,                      2025,  182500.0,         10000.0
-        QLD,     Small__OCGT,               2025,  500000.0,         0.0
-        TAS,     Solar__Thermal,            2025,  100000.0,         0.0
+        geo_id,  technology,            year,  connection_cost,  system_strength_cost
+        N1,      Large scale Solar PV,  2025,  182500.0,         10000.0
+        N1,      Wind,                  2025,  182500.0,         10000.0
+        QLD,     Small OCGT,            2025,  500000.0,         0.0
+        TAS,     Solar Thermal,         2025,  100000.0,         0.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(["geo_id", "technology"]).reset_index(drop=True),
@@ -555,23 +555,23 @@ def test_get_unique_vre_geo_id_rows(csv_str_to_df):
     # Input is assumed already deduplicated upstream — this function does not dedup.
     canonical_tech_geo_ids = csv_str_to_df("""
         geo_id,  technology
-        N1,      Large__scale__Solar__PV
+        N1,      Large scale Solar PV
         N1,      Wind
-        NNSW,    Pumped__Hydro__(24hrs__storage)
-        Q9,      Large__scale__Solar__PV
-        V8,      Wind__-__offshore__(fixed)
-        GG,      Distributed__Resources__Batteries
-        SESA,    Distributed__Resources__Solar
+        NNSW,    Pumped Hydro (24hrs storage)
+        Q9,      Large scale Solar PV
+        V8,      Wind - offshore (fixed)
+        GG,      Distributed Resources Batteries
+        SESA,    Distributed Resources Solar
     """)
 
     result = _get_unique_vre_geo_id_rows(canonical_tech_geo_ids)
 
     expected = csv_str_to_df("""
         geo_id,  technology
-        N1,      Large__scale__Solar__PV
+        N1,      Large scale Solar PV
         N1,      Wind
-        Q9,      Large__scale__Solar__PV
-        V8,      Wind__-__offshore__(fixed)
+        Q9,      Large scale Solar PV
+        V8,      Wind - offshore (fixed)
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(_GEO_TECH_COLS).reset_index(drop=True),
@@ -606,10 +606,10 @@ def test_build_vre_cost_rows(csv_str_to_df):
     """)
     vre_technologies = csv_str_to_df("""
         geo_id,  technology
-        N1,      Large__scale__Solar__PV
+        N1,      Large scale Solar PV
         N1,      Wind
-        Q9,      Large__scale__Solar__PV
-        V8,      Wind__-__offshore__(fixed)
+        Q9,      Large scale Solar PV
+        V8,      Wind - offshore (fixed)
     """)
 
     result = _build_vre_cost_rows(costs_per_mw, vre_technologies)
@@ -618,12 +618,12 @@ def test_build_vre_cost_rows(csv_str_to_df):
         geo_id,  technology,                    year,  connection_cost
         N1,      Wind,                          2025,  182500.0
         N1,      Wind,                          2026,  185000.0
-        N1,      Large__scale__Solar__PV,       2025,  182500.0
-        N1,      Large__scale__Solar__PV,       2026,  185000.0
-        Q9,      Large__scale__Solar__PV,       2025,  474444.4
-        Q9,      Large__scale__Solar__PV,       2026,  481666.7
-        V8,      Wind__-__offshore__(fixed),    2025,
-        V8,      Wind__-__offshore__(fixed),    2026,
+        N1,      Large scale Solar PV,          2025,  182500.0
+        N1,      Large scale Solar PV,          2026,  185000.0
+        Q9,      Large scale Solar PV,          2025,  474444.4
+        Q9,      Large scale Solar PV,          2026,  481666.7
+        V8,      Wind - offshore (fixed),       2025,
+        V8,      Wind - offshore (fixed),       2026,
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(["geo_id", "technology", "year"]).reset_index(drop=True),
@@ -685,12 +685,12 @@ def test_build_vre_cost_rows_empty_inputs(csv_str_to_df):
 
 def test_template_vre_connection_costs(csv_str_to_df, caplog):
     connection_cost_forecast_vre = csv_str_to_df("""
-        REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
-        N1,       North__West__NSW, Step__Change, 73000000,   74000000
-        Q9,       Banana,           Step__Change, 854000000,  867000000
+        REZ ID,  REZ names,         Scenario,     2024-25,    2025-26
+        N1,      North West NSW,    Step Change, 73000000,   74000000
+        Q9,      Banana,            Step Change, 854000000,  867000000
     """)
     connection_costs_for_vre = csv_str_to_df("""
-        REZ__ID,    Connection__capacity__(MVA)
+        REZ ID,     Connection capacity (MVA)
         N1,         400
         Q9,         1800
         V8,
@@ -698,11 +698,11 @@ def test_template_vre_connection_costs(csv_str_to_df, caplog):
     canonical_technology_geo_id_pairs = csv_str_to_df("""
         geo_id,     technology
         N1,         Wind
-        N1,         Large__scale__Solar__PV
-        Q9,         Large__scale__Solar__PV
-        V8,         Wind__-__offshore__(fixed)
+        N1,         Large scale Solar PV
+        Q9,         Large scale Solar PV
+        V8,         Wind - offshore (fixed)
         NNSW,       CCGT
-        SQ,         Pumped__Hydro
+        SQ,         Pumped Hydro
     """)
 
     with caplog.at_level("WARNING"):
@@ -724,10 +724,10 @@ def test_template_vre_connection_costs(csv_str_to_df, caplog):
 def test_template_vre_connection_costs_all_empty_inputs(csv_str_to_df):
     # test that even with all empty inputs we get an empty df with expected columns.
     connection_cost_forecast_vre = csv_str_to_df("""
-        REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
+        REZ ID,  REZ names,       Scenario,     2024-25,    2025-26
     """)
     connection_costs_for_vre = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
+        REZ ID,  Connection capacity (MVA)
     """)
 
     result = _template_vre_connection_costs(
@@ -745,12 +745,12 @@ def test_template_vre_connection_costs_some_empty_inputs(csv_str_to_df):
     # test that even with combinations of empty/full inputs we get an empty df
     # with expected columns.
     connection_cost_forecast_vre = csv_str_to_df("""
-        REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
-        N1,       North__West__NSW, Step__Change, 73000000,   74000000
-        Q9,       Banana,           Step__Change, 854000000,  867000000
+        REZ ID, REZ names,          Scenario,     2024-25,    2025-26
+        N1,     North West NSW,     Step Change, 73000000,   74000000
+        Q9,     Banana,             Step Change, 854000000,  867000000
     """)
     empty_capacity = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
+        REZ ID,  Connection capacity (MVA)
     """)
 
     result = _template_vre_connection_costs(
@@ -765,7 +765,7 @@ def test_template_vre_connection_costs_some_empty_inputs(csv_str_to_df):
 
     # non-empty vre_technologies_by_geo_id input -> empty output
     empty_forecast = csv_str_to_df("""
-        REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
+        REZ ID,  REZ names,       Scenario,     2024-25,    2025-26
     """)
     vre_technologies_by_geo_id = csv_str_to_df("""
         geo_id,  technology
@@ -786,12 +786,12 @@ def test_template_vre_connection_costs_some_empty_inputs(csv_str_to_df):
 def test_template_vre_connection_costs_empty_capacity_gives_nan_costs(csv_str_to_df):
     # Non-empty forecast and technologies but empty capacity -> NaN connection_cost
     connection_cost_forecast_vre = csv_str_to_df("""
-        REZ__ID,  REZ__names,       Scenario,     2024-25,    2025-26
-        N1,       North__West__NSW, Step__Change, 73000000,   74000000
-        Q9,       Banana,           Step__Change, 854000000,  867000000
+        REZ ID, REZ names,          Scenario,     2024-25,    2025-26
+        N1,     North West NSW,     Step Change, 73000000,   74000000
+        Q9,     Banana,             Step Change, 854000000,  867000000
     """)
     empty_capacity = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
+        REZ ID,  Connection capacity (MVA)
     """)
     vre_technologies_by_geo_id = csv_str_to_df("""
         geo_id,  technology
@@ -830,7 +830,7 @@ def test_get_canon_technology_and_geo_id_pairs(csv_str_to_df):
     """)
     storage_new_entrant = csv_str_to_df("""
         geo_id,  technology
-        CNSW,    Battery__Storage__(4h)
+        CNSW,    Battery Storage (4h)
     """)
 
     result = _get_canon_technology_and_geo_id_pairs(
@@ -841,7 +841,7 @@ def test_get_canon_technology_and_geo_id_pairs(csv_str_to_df):
         geo_id,  technology
         N1,      Wind
         CNSW,    CCGT
-        CNSW,    Battery__Storage__(4h)
+        CNSW,    Battery Storage (4h)
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(_GEO_TECH_COLS).reset_index(drop=True),
@@ -857,8 +857,8 @@ def test_canonicalise_non_vre_technologies(csv_str_to_df):
     df = csv_str_to_df("""
         region_id,  technology,         year,  connection_capacity,  connection_cost
         NSW,        CCGT,               2025,  400,                  40000000.0
-        NSW,        OCGT__small__GT,    2025,  400,                  32000000.0
-        TAS,        BOTN__-__Cethana,   2025,  250,                  0.0
+        NSW,        OCGT small GT,      2025,  400,                  32000000.0
+        TAS,        BOTN - Cethana,     2025,  250,                  0.0
     """)
     canonical_technologies = {"CCGT", "OCGT (small GT)"}
 
@@ -867,7 +867,7 @@ def test_canonicalise_non_vre_technologies(csv_str_to_df):
     expected = csv_str_to_df("""
         region_id,  technology,         year,  connection_capacity,  connection_cost
         NSW,        CCGT,               2025,  400,                  40000000.0
-        NSW,        OCGT__(small__GT),  2025,  400,                  32000000.0
+        NSW,        OCGT (small GT),    2025,  400,                  32000000.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(["region_id", "technology"]).reset_index(drop=True),
@@ -922,10 +922,10 @@ def test_create_non_vre_rez_cost_rows(csv_str_to_df):
     # subregions, not REZs) excluded; NQ Wind (VRE, not REZ) excluded.
     canon_tech_geo_id_pairs = csv_str_to_df("""
         geo_id,     technology
-        S1,         Battery__Storage__(4h)
+        S1,         Battery Storage (4h)
         S1,         CCGT
         S1,         Wind
-        CSA,        Battery__Storage__(4h)
+        CSA,        Battery Storage (4h)
         NQ,         CCGT
         NQ,         Wind
     """)
@@ -937,8 +937,8 @@ def test_create_non_vre_rez_cost_rows(csv_str_to_df):
     """)
     connection_costs = csv_str_to_df("""
         region_id,  technology,             year,   connection_cost
-        SA,         Battery__Storage__(4h), 2025,   90000.0
-        SA,         Battery__Storage__(4h), 2026,   95000.0
+        SA,         Battery Storage (4h),   2025,   90000.0
+        SA,         Battery Storage (4h),   2026,   95000.0
         QLD,        CCGT,                   2025,   100000.0
         QLD,        CCGT,                   2026,   110000.0
     """)
@@ -947,8 +947,8 @@ def test_create_non_vre_rez_cost_rows(csv_str_to_df):
     )
     expected = csv_str_to_df("""
         geo_id,     technology,             year,   connection_cost
-        S1,         Battery__Storage__(4h), 2025,   90000.0
-        S1,         Battery__Storage__(4h), 2026,   95000.0
+        S1,         Battery Storage (4h),   2025,   90000.0
+        S1,         Battery Storage (4h),   2026,   95000.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values(["geo_id", "year"]).reset_index(drop=True),
@@ -961,7 +961,7 @@ def test_create_non_vre_rez_cost_rows_empty_inputs(csv_str_to_df):
     # Combinatorial empty inputs testing
     pairs = csv_str_to_df("""
         geo_id,     technology
-        S1,         Battery__Storage__(4h)
+        S1,         Battery Storage (4h)
     """)
     geography = csv_str_to_df("""
         geo_id,     geo_type,       region_id
@@ -969,14 +969,14 @@ def test_create_non_vre_rez_cost_rows_empty_inputs(csv_str_to_df):
     """)
     costs = csv_str_to_df("""
         region_id,  technology,             year,   connection_cost
-        SA,         Battery__Storage__(4h), 2025,   90000.0
+        SA,         Battery Storage (4h),   2025,   90000.0
     """)
     empty_pairs = pd.DataFrame(columns=pairs.columns)
     empty_geography = pd.DataFrame(columns=geography.columns)
     empty_costs = pd.DataFrame(columns=costs.columns)
 
     expected = pd.DataFrame(columns=_CONNECTION_ONLY_COST_COLS)
-    # A emtpy
+    # A empty
     pd.testing.assert_frame_equal(
         _create_non_vre_rez_cost_rows(empty_pairs, geography, costs).reset_index(
             drop=True
@@ -984,7 +984,7 @@ def test_create_non_vre_rez_cost_rows_empty_inputs(csv_str_to_df):
         expected.reset_index(drop=True),
         check_dtype=False,
     )
-    # B emtpy
+    # B empty
     pd.testing.assert_frame_equal(
         _create_non_vre_rez_cost_rows(pairs, empty_geography, costs).reset_index(
             drop=True
@@ -992,7 +992,7 @@ def test_create_non_vre_rez_cost_rows_empty_inputs(csv_str_to_df):
         expected.reset_index(drop=True),
         check_dtype=False,
     )
-    # C emtpy
+    # C empty
     pd.testing.assert_frame_equal(
         _create_non_vre_rez_cost_rows(pairs, geography, empty_costs).reset_index(
             drop=True
@@ -1000,7 +1000,7 @@ def test_create_non_vre_rez_cost_rows_empty_inputs(csv_str_to_df):
         expected.reset_index(drop=True),
         check_dtype=False,
     )
-    # All emtpy
+    # All empty
     pd.testing.assert_frame_equal(
         _create_non_vre_rez_cost_rows(
             empty_pairs, empty_geography, empty_costs
@@ -1018,8 +1018,8 @@ def test_expand_non_vre_connection_costs_to_subregions(csv_str_to_df):
     # geography are ignored (inner merge on subregions only).
     non_vre_connection_costs = csv_str_to_df("""
         region_id,  technology,         year,  connection_cost
-        QLD,        OCGT__(small__GT),  2025,  120000.0
-        QLD,        OCGT__(small__GT),  2026,  130000.0
+        QLD,        OCGT (small GT),    2025,  120000.0
+        QLD,        OCGT (small GT),    2026,  130000.0
     """)
     sub_regional_geography = csv_str_to_df("""
         geo_id,  geo_type,   region_id
@@ -1033,11 +1033,11 @@ def test_expand_non_vre_connection_costs_to_subregions(csv_str_to_df):
     )
 
     expected = csv_str_to_df("""
-        geo_id,  technology,         year,  connection_cost
-        NQ,      OCGT__(small__GT),  2025,  120000.0
-        NQ,      OCGT__(small__GT),  2026,  130000.0
-        CQ,      OCGT__(small__GT),  2025,  120000.0
-        CQ,      OCGT__(small__GT),  2026,  130000.0
+        geo_id,  technology,        year,  connection_cost
+        NQ,      OCGT (small GT),   2025,  120000.0
+        NQ,      OCGT (small GT),   2026,  130000.0
+        CQ,      OCGT (small GT),   2025,  120000.0
+        CQ,      OCGT (small GT),   2026,  130000.0
     """)
     pd.testing.assert_frame_equal(
         result.sort_values("geo_id").reset_index(drop=True),
@@ -1051,7 +1051,7 @@ def test_expand_non_vre_connection_costs_to_subregions_empty_inputs(csv_str_to_d
     # ``_CONNECTION_ONLY_COST_COLS``
     costs = csv_str_to_df("""
         region_id,  technology,         year,  connection_cost
-        QLD,        OCGT__(small__GT),  2025,  120000.0
+        QLD,        OCGT (small GT),    2025,  120000.0
     """)
     empty_costs = pd.DataFrame(columns=costs.columns)
     geography = csv_str_to_df("""
@@ -1093,21 +1093,21 @@ def test_expand_non_vre_connection_costs_to_subregions_empty_inputs(csv_str_to_d
 def test_average_connection_costs_across_regions(csv_str_to_df):
     # Costs averaged across regions per (technology, year); geo_id set to "NEM".
     non_vre_connection_costs = csv_str_to_df("""
-        region_id,  technology,         year,  connection_cost
-        NSW,        OCGT__(small__GT),  2025,  100000.0
-        NSW,        OCGT__(small__GT),  2026,  110000.0
-        QLD,        OCGT__(small__GT),  2025,  120000.0
-        QLD,        OCGT__(small__GT),  2026,  130000.0
-        VIC,        OCGT__(small__GT),  2025,  80000.0
-        VIC,        OCGT__(small__GT),  2026,  90000.0
+        region_id,  technology,       year,  connection_cost
+        NSW,        OCGT (small GT),  2025,  100000.0
+        NSW,        OCGT (small GT),  2026,  110000.0
+        QLD,        OCGT (small GT),  2025,  120000.0
+        QLD,        OCGT (small GT),  2026,  130000.0
+        VIC,        OCGT (small GT),  2025,  80000.0
+        VIC,        OCGT (small GT),  2026,  90000.0
     """)
 
     result = _average_connection_costs_across_regions(non_vre_connection_costs)
 
     expected = csv_str_to_df("""
-        geo_id,  technology,         year,  connection_cost
-        NEM,     OCGT__(small__GT),  2025,  100000.0
-        NEM,     OCGT__(small__GT),  2026,  110000.0
+        geo_id,  technology,       year,  connection_cost
+        NEM,     OCGT (small GT),  2025,  100000.0
+        NEM,     OCGT (small GT),  2026,  110000.0
     """)
     pd.testing.assert_frame_equal(
         result.reset_index(drop=True),
@@ -1138,20 +1138,20 @@ def test_filter_connection_costs_by_regional_granularity(csv_str_to_df):
     # All three branches share inputs; each appends the REZ-battery row (N1,
     # inheriting the NSW cost). Asserted per branch below (wiring).
     non_vre_connection_costs = csv_str_to_df("""
-        region_id,  technology,              year,  connection_cost
-        NSW,        CCGT,                    2025,  100000.0
-        NSW,        Battery__Storage__(4h),  2025,  50000.0
-        QLD,        CCGT,                    2025,  120000.0
-        QLD,        Battery__Storage__(4h),  2025,  60000.0
+        region_id,  technology,             year,  connection_cost
+        NSW,        CCGT,                   2025,  100000.0
+        NSW,        Battery Storage (4h),   2025,  50000.0
+        QLD,        CCGT,                   2025,  120000.0
+        QLD,        Battery Storage (4h),   2025,  60000.0
     """)
     canon_tech_geo_id_pairs = csv_str_to_df("""
         geo_id,  technology
-        N1,      Battery__Storage__(4h)
-        SNW,     Battery__Storage__(4h)
+        N1,      Battery Storage (4h)
+        SNW,     Battery Storage (4h)
         SNW,     CCGT
-        CQ,      Battery__Storage__(4h)
+        CQ,      Battery Storage (4h)
         CQ,      CCGT
-        NQ,      Battery__Storage__(4h)
+        NQ,      Battery Storage (4h)
         NQ,      CCGT
     """)
     sub_regional_geography = csv_str_to_df("""
@@ -1226,22 +1226,22 @@ def test_filter_connection_costs_by_regional_granularity_invalid_raises(csv_str_
 
 def test_template_non_vre_connection_costs(csv_str_to_df):
     connection_cost_forecast_other = csv_str_to_df("""
-        Generator__Type,        Region,     Scenario,       2024-25,    2025-26
-        CCGT,                   NSW,        Step__Change,   40000000,   41000000
-        Battery__Storage__(4h), NSW,        Step__Change,   20000000,   22000000
+        Generator Type,         Region,     Scenario,       2024-25,    2025-26
+        CCGT,                   NSW,        Step Change,    40000000,   41000000
+        Battery Storage (4h),   NSW,        Step Change,    20000000,   22000000
     """)
     connection_capacity_df = csv_str_to_df("""
-        Region,     Generator__Type,        Connection__capacity__(MVA)
-        NSW,        CCGT,                   400
-        NSW,        Battery__Storage__(4h), 400
+        Region,     Generator Type,        Connection capacity (MVA)
+        NSW,        CCGT,                  400
+        NSW,        Battery Storage (4h),  400
     """)
     canon_tech_geo_id_pairs = csv_str_to_df("""
         geo_id,     technology
         CNSW,       CCGT
-        CNSW,       Battery__Storage__(4h)
+        CNSW,       Battery Storage (4h)
         SNW,        CCGT
-        SNW,        Battery__Storage__(4h)
-        N1,         Battery__Storage__(4h)
+        SNW,        Battery Storage (4h)
+        N1,         Battery Storage (4h)
     """)
     sub_regional_geography = csv_str_to_df("""
         geo_id,     geo_type,   region_id
@@ -1292,12 +1292,12 @@ def test_template_non_vre_connection_costs(csv_str_to_df):
 def test_template_non_vre_connection_costs_empty_inputs(csv_str_to_df):
     # Some checks that should return an empty df with ``_CONNECTION_ONLY_COST_COLS``.
     forecast = csv_str_to_df("""
-        Generator__Type,        Region,     Scenario,       2024-25,    2025-26
-        CCGT,                   NSW,        Step__Change,   40000000,   41000000
+        Generator Type,        Region,     Scenario,       2024-25,    2025-26
+        CCGT,                  NSW,        Step Change,   40000000,   41000000
     """)
     capacity = csv_str_to_df("""
-        Region,     Generator__Type,        Connection__capacity__(MVA)
-        NSW,        CCGT,                   400
+        Region,     Generator Type,        Connection capacity (MVA)
+        NSW,        CCGT,                  400
     """)
     # all empty inputs
     result_all_empty = _template_non_vre_connection_costs(
@@ -1310,7 +1310,7 @@ def test_template_non_vre_connection_costs_empty_inputs(csv_str_to_df):
     )
     assert list(result_all_empty.columns) == _CONNECTION_ONLY_COST_COLS
     assert result_all_empty.empty
-    # emtpy tech/geography inputs:
+    # empty tech/geography inputs:
     result_some_empty = _template_non_vre_connection_costs(
         forecast,
         capacity,
@@ -1329,8 +1329,8 @@ def test_template_non_vre_connection_costs_empty_capacity_gives_nan_costs(
     # Non-empty forecast, technologies and geography but empty capacity
     # -> present but NaN connection_cost
     forecast = csv_str_to_df("""
-        Generator__Type,        Region,     Scenario,       2024-25,    2025-26
-        CCGT,                   NSW,        Step__Change,   40000000,   41000000
+        Generator Type,        Region,     Scenario,       2024-25,    2025-26
+        CCGT,                  NSW,        Step Change,   40000000,   41000000
     """)
     empty_capacity = pd.DataFrame(
         columns=["Region", "Generator Type", "Connection capacity (MVA)"]
@@ -1366,22 +1366,22 @@ def test_template_connection_costs(csv_str_to_df):
     # per-helper unit tests above, so we assert column set + row count only.
     iasr_tables = {
         "connection_cost_forecast_wind_and_solar": csv_str_to_df("""
-            REZ__ID,  Scenario,      2024-25
-            N1,       Step__Change,  73000000
+            REZ ID,  Scenario,      2024-25
+            N1,      Step Change,  73000000
         """),
         "connection_costs_for_wind_and_solar": csv_str_to_df("""
-            REZ__ID,  Connection__capacity__(MVA)
-            N1,       400
+            REZ ID,  Connection capacity (MVA)
+            N1,      400
         """),
         "connection_cost_forecast_other": csv_str_to_df("""
-            Generator__Type,         Region,  Scenario,      2024-25
-            CCGT,                    NSW,     Step__Change,  40000000
-            Battery__Storage__(4h),  NSW,     Step__Change,  20000000
+            Generator Type,         Region,  Scenario,      2024-25
+            CCGT,                   NSW,     Step Change,  40000000
+            Battery Storage (4h),   NSW,     Step Change,  20000000
         """),
         "connection_capacity_non_vre": csv_str_to_df("""
-            Region,  Generator__Type,         Connection__capacity__(MVA)
-            NSW,     CCGT,                    400
-            NSW,     Battery__Storage__(4h),  400
+            Region,  Generator Type,         Connection capacity (MVA)
+            NSW,     CCGT,                   400
+            NSW,     Battery Storage (4h),   400
         """),
         "efficient_level_of_system_strength_cost": csv_str_to_df("""
             label,  2024-25
@@ -1395,8 +1395,8 @@ def test_template_connection_costs(csv_str_to_df):
     """)
     storage_new_entrant = csv_str_to_df("""
         geo_id,  technology
-        CNSW,    Battery__Storage__(4h)
-        N1,      Battery__Storage__(4h)
+        CNSW,    Battery Storage (4h)
+        N1,      Battery Storage (4h)
     """)
     sub_regional_geography = csv_str_to_df("""
         geo_id,  geo_type,   region_id
@@ -1423,16 +1423,16 @@ def test_template_connection_costs_empty_inputs_give_empty_output(csv_str_to_df)
     # All empty inputs -> empty output with all expected columns present.
     iasr_tables = {
         "connection_cost_forecast_wind_and_solar": csv_str_to_df("""
-            REZ__ID,  Scenario,  2024-25
+            REZ ID,  Scenario,  2024-25
         """),
         "connection_costs_for_wind_and_solar": csv_str_to_df("""
-            REZ__ID,  Connection__capacity__(MVA)
+            REZ ID,  Connection capacity (MVA)
         """),
         "connection_cost_forecast_other": csv_str_to_df("""
-            Generator__Type,  Region,  Scenario,  2024-25
+            Generator Type,  Region,  Scenario,  2024-25
         """),
         "connection_capacity_non_vre": csv_str_to_df("""
-            Region,  Generator__Type,  Connection__capacity__(MVA)
+            Region,  Generator Type,  Connection capacity (MVA)
         """),
         "efficient_level_of_system_strength_cost": csv_str_to_df("""
             label,  2024-25

--- a/tests/test_templater/test_create_ispypsa_inputs_template.py
+++ b/tests/test_templater/test_create_ispypsa_inputs_template.py
@@ -246,9 +246,19 @@ def test_create_ispypsa_inputs_template_new_format(csv_str_to_df):
                 "rez_augmentation_costs_step_change_NSW": rez_aug_costs_nsw,
                 "connection_cost_forecast_wind_and_solar": connection_cost_forecast_wind_and_solar,
                 "connection_costs_for_wind_and_solar": connection_costs_for_wind_and_solar,
+                "connection_cost_forecast_other": csv_str_to_df("""
+                    Generator__Type,  Region,  Scenario,  2024-25
+                """),
                 "efficient_level_of_system_strength_cost": efficient_level_of_system_strength_cost,
             },
-            manually_extracted_tables={},
+            # connection_capacity_non_vre is popped out of manually_extracted_tables
+            # into iasr_tables by create_template; supply it (header-only) so the
+            # wiring runs. Output stays empty: generators/storage are placeholder-empty.
+            manually_extracted_tables={
+                "connection_capacity_non_vre": csv_str_to_df("""
+                    Region,  Generator__Type,  Connection__capacity__(MVA)
+                """),
+            },
             iasr_workbook_version="ignored-by-patch",
         )
 
@@ -420,9 +430,16 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
                 "rez_augmentation_costs_step_change_NSW": rez_aug_costs_nsw,
                 "connection_cost_forecast_wind_and_solar": connection_cost_forecast_wind_and_solar,
                 "connection_costs_for_wind_and_solar": connection_costs_for_wind_and_solar,
+                "connection_cost_forecast_other": csv_str_to_df("""
+                    Generator__Type,  Region,  Scenario,  2024-25
+                """),
                 "efficient_level_of_system_strength_cost": efficient_level_of_system_strength_cost,
             },
-            manually_extracted_tables={},
+            manually_extracted_tables={
+                "connection_capacity_non_vre": csv_str_to_df("""
+                    Region,  Generator__Type,  Connection__capacity__(MVA)
+                """),
+            },
             iasr_workbook_version="ignored-by-patch",
         )
 
@@ -547,9 +564,16 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
                 "rez_augmentation_costs_step_change_NSW": rez_aug_costs_nsw,
                 "connection_cost_forecast_wind_and_solar": connection_cost_forecast_wind_and_solar,
                 "connection_costs_for_wind_and_solar": connection_costs_for_wind_and_solar,
+                "connection_cost_forecast_other": csv_str_to_df("""
+                    Generator__Type,  Region,  Scenario,  2024-25
+                """),
                 "efficient_level_of_system_strength_cost": efficient_level_of_system_strength_cost,
             },
-            manually_extracted_tables={},
+            manually_extracted_tables={
+                "connection_capacity_non_vre": csv_str_to_df("""
+                    Region,  Generator__Type,  Connection__capacity__(MVA)
+                """),
+            },
             iasr_workbook_version="ignored-by-patch",
         )
 

--- a/tests/test_templater/test_create_ispypsa_inputs_template.py
+++ b/tests/test_templater/test_create_ispypsa_inputs_template.py
@@ -206,14 +206,21 @@ def test_create_ispypsa_inputs_template_new_format(csv_str_to_df):
         REZ / Constraint ID,  Option,    2024-25,  2025-26
         N3,                   Option 1,  750000,   760000
     """)
-
     connection_cost_forecast_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Scenario,     2024-25
-        Q1,       Step__Change, 73000000
+        REZ__ID,  Scenario,     2024-25,    2025-26
+        Q1,       Step__Change, 73000000,   74000000
     """)
     connection_costs_for_wind_and_solar = csv_str_to_df("""
         REZ__ID,  Connection__capacity__(MVA)
         Q1,       400
+    """)
+    connection_cost_forecast_other = csv_str_to_df("""
+        Generator__Type,            Region,  Scenario,      2024-25,    2025-26
+        Battery__Storage__(4h),     NSW,     Step__Change,  20000000,   22000000
+    """)
+    connection_capacity_non_vre = csv_str_to_df("""
+        Region,  Generator__Type,         Connection__capacity__(MVA)
+        NSW,     Battery__Storage__(4h),  400
     """)
     efficient_level_of_system_strength_cost = csv_str_to_df("""
         label,  2024-25
@@ -246,18 +253,14 @@ def test_create_ispypsa_inputs_template_new_format(csv_str_to_df):
                 "rez_augmentation_costs_step_change_NSW": rez_aug_costs_nsw,
                 "connection_cost_forecast_wind_and_solar": connection_cost_forecast_wind_and_solar,
                 "connection_costs_for_wind_and_solar": connection_costs_for_wind_and_solar,
-                "connection_cost_forecast_other": csv_str_to_df("""
-                    Generator__Type,  Region,  Scenario,  2024-25
-                """),
+                "connection_cost_forecast_other": connection_cost_forecast_other,
                 "efficient_level_of_system_strength_cost": efficient_level_of_system_strength_cost,
             },
             # connection_capacity_non_vre is popped out of manually_extracted_tables
-            # into iasr_tables by create_template; supply it (header-only) so the
+            # into iasr_tables by create_template; supplied so the
             # wiring runs. Output stays empty: generators/storage are placeholder-empty.
             manually_extracted_tables={
-                "connection_capacity_non_vre": csv_str_to_df("""
-                    Region,  Generator__Type,  Connection__capacity__(MVA)
-                """),
+                "connection_capacity_non_vre": connection_capacity_non_vre,
             },
             iasr_workbook_version="ignored-by-patch",
         )
@@ -392,12 +395,20 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
         N3,                   Option 1,  750000,   760000
     """)
     connection_cost_forecast_wind_and_solar = csv_str_to_df("""
-        REZ__ID,    Scenario,       2024-25
-        Q1,         Step__Change,   73000000
+        REZ__ID,  Scenario,     2024-25,    2025-26
+        Q1,       Step__Change, 73000000,   74000000
     """)
     connection_costs_for_wind_and_solar = csv_str_to_df("""
-        REZ__ID,    Connection__capacity__(MVA)
-        Q1,         400
+        REZ__ID,  Connection__capacity__(MVA)
+        Q1,       400
+    """)
+    connection_cost_forecast_other = csv_str_to_df("""
+        Generator__Type,            Region,  Scenario,      2024-25,    2025-26
+        Battery__Storage__(4h),     NSW,     Step__Change,  20000000,   22000000
+    """)
+    connection_capacity_non_vre = csv_str_to_df("""
+        Region,  Generator__Type,         Connection__capacity__(MVA)
+        NSW,     Battery__Storage__(4h),  400
     """)
     efficient_level_of_system_strength_cost = csv_str_to_df("""
         label,  2024-25
@@ -430,15 +441,11 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
                 "rez_augmentation_costs_step_change_NSW": rez_aug_costs_nsw,
                 "connection_cost_forecast_wind_and_solar": connection_cost_forecast_wind_and_solar,
                 "connection_costs_for_wind_and_solar": connection_costs_for_wind_and_solar,
-                "connection_cost_forecast_other": csv_str_to_df("""
-                    Generator__Type,  Region,  Scenario,  2024-25
-                """),
+                "connection_cost_forecast_other": connection_cost_forecast_other,
                 "efficient_level_of_system_strength_cost": efficient_level_of_system_strength_cost,
             },
             manually_extracted_tables={
-                "connection_capacity_non_vre": csv_str_to_df("""
-                    Region,  Generator__Type,  Connection__capacity__(MVA)
-                """),
+                "connection_capacity_non_vre": connection_capacity_non_vre,
             },
             iasr_workbook_version="ignored-by-patch",
         )
@@ -528,12 +535,20 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
         N3,                   Option 1,  750000,   760000
     """)
     connection_cost_forecast_wind_and_solar = csv_str_to_df("""
-        REZ__ID,    Scenario,       2024-25
-        Q1,         Step__Change,   73000000
+        REZ__ID,  Scenario,     2024-25,    2025-26
+        Q1,       Step__Change, 73000000,   74000000
     """)
     connection_costs_for_wind_and_solar = csv_str_to_df("""
-        REZ__ID,    Connection__capacity__(MVA)
-        Q1,         400
+        REZ__ID,  Connection__capacity__(MVA)
+        Q1,       400
+    """)
+    connection_cost_forecast_other = csv_str_to_df("""
+        Generator__Type,            Region,  Scenario,      2024-25,    2025-26
+        Battery__Storage__(4h),     NSW,     Step__Change,  20000000,   22000000
+    """)
+    connection_capacity_non_vre = csv_str_to_df("""
+        Region,  Generator__Type,         Connection__capacity__(MVA)
+        NSW,     Battery__Storage__(4h),  400
     """)
     efficient_level_of_system_strength_cost = csv_str_to_df("""
         label,  2024-25
@@ -564,15 +579,11 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
                 "rez_augmentation_costs_step_change_NSW": rez_aug_costs_nsw,
                 "connection_cost_forecast_wind_and_solar": connection_cost_forecast_wind_and_solar,
                 "connection_costs_for_wind_and_solar": connection_costs_for_wind_and_solar,
-                "connection_cost_forecast_other": csv_str_to_df("""
-                    Generator__Type,  Region,  Scenario,  2024-25
-                """),
+                "connection_cost_forecast_other": connection_cost_forecast_other,
                 "efficient_level_of_system_strength_cost": efficient_level_of_system_strength_cost,
             },
             manually_extracted_tables={
-                "connection_capacity_non_vre": csv_str_to_df("""
-                    Region,  Generator__Type,  Connection__capacity__(MVA)
-                """),
+                "connection_capacity_non_vre": connection_capacity_non_vre,
             },
             iasr_workbook_version="ignored-by-patch",
         )

--- a/tests/test_templater/test_create_ispypsa_inputs_template.py
+++ b/tests/test_templater/test_create_ispypsa_inputs_template.py
@@ -207,20 +207,20 @@ def test_create_ispypsa_inputs_template_new_format(csv_str_to_df):
         N3,                   Option 1,  750000,   760000
     """)
     connection_cost_forecast_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Scenario,     2024-25,    2025-26
-        Q1,       Step__Change, 73000000,   74000000
+        REZ ID,  Scenario,     2024-25,    2025-26
+        Q1,       Step Change, 73000000,   74000000
     """)
     connection_costs_for_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
+        REZ ID,  Connection capacity (MVA)
         Q1,       400
     """)
     connection_cost_forecast_other = csv_str_to_df("""
-        Generator__Type,            Region,  Scenario,      2024-25,    2025-26
-        Battery__Storage__(4h),     NSW,     Step__Change,  20000000,   22000000
+        Generator Type,            Region,  Scenario,      2024-25,    2025-26
+        Battery Storage (4h),     NSW,     Step Change,  20000000,   22000000
     """)
     connection_capacity_non_vre = csv_str_to_df("""
-        Region,  Generator__Type,         Connection__capacity__(MVA)
-        NSW,     Battery__Storage__(4h),  400
+        Region,  Generator Type,         Connection capacity (MVA)
+        NSW,     Battery Storage (4h),  400
     """)
     efficient_level_of_system_strength_cost = csv_str_to_df("""
         label,  2024-25
@@ -395,20 +395,20 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
         N3,                   Option 1,  750000,   760000
     """)
     connection_cost_forecast_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Scenario,     2024-25,    2025-26
-        Q1,       Step__Change, 73000000,   74000000
+        REZ ID,  Scenario,     2024-25,    2025-26
+        Q1,       Step Change, 73000000,   74000000
     """)
     connection_costs_for_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
+        REZ ID,  Connection capacity (MVA)
         Q1,       400
     """)
     connection_cost_forecast_other = csv_str_to_df("""
-        Generator__Type,            Region,  Scenario,      2024-25,    2025-26
-        Battery__Storage__(4h),     NSW,     Step__Change,  20000000,   22000000
+        Generator Type,            Region,  Scenario,      2024-25,    2025-26
+        Battery Storage (4h),     NSW,     Step Change,  20000000,   22000000
     """)
     connection_capacity_non_vre = csv_str_to_df("""
-        Region,  Generator__Type,         Connection__capacity__(MVA)
-        NSW,     Battery__Storage__(4h),  400
+        Region,  Generator Type,         Connection capacity (MVA)
+        NSW,     Battery Storage (4h),  400
     """)
     efficient_level_of_system_strength_cost = csv_str_to_df("""
         label,  2024-25
@@ -535,20 +535,20 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
         N3,                   Option 1,  750000,   760000
     """)
     connection_cost_forecast_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Scenario,     2024-25,    2025-26
-        Q1,       Step__Change, 73000000,   74000000
+        REZ ID,  Scenario,     2024-25,    2025-26
+        Q1,       Step Change, 73000000,   74000000
     """)
     connection_costs_for_wind_and_solar = csv_str_to_df("""
-        REZ__ID,  Connection__capacity__(MVA)
+        REZ ID,  Connection capacity (MVA)
         Q1,       400
     """)
     connection_cost_forecast_other = csv_str_to_df("""
-        Generator__Type,            Region,  Scenario,      2024-25,    2025-26
-        Battery__Storage__(4h),     NSW,     Step__Change,  20000000,   22000000
+        Generator Type,            Region,  Scenario,      2024-25,    2025-26
+        Battery Storage (4h),     NSW,     Step Change,  20000000,   22000000
     """)
     connection_capacity_non_vre = csv_str_to_df("""
-        Region,  Generator__Type,         Connection__capacity__(MVA)
-        NSW,     Battery__Storage__(4h),  400
+        Region,  Generator Type,         Connection capacity (MVA)
+        NSW,     Battery Storage (4h),  400
     """)
     efficient_level_of_system_strength_cost = csv_str_to_df("""
         label,  2024-25

--- a/tests/test_templater/test_helpers.py
+++ b/tests/test_templater/test_helpers.py
@@ -366,7 +366,7 @@ def test_rez_name_to_id_mapping_empty_input():
     pd.testing.assert_series_equal(result, expected)
 
 
-def test_looks_like_financial_year_matches_only_canonical_format():
+def test_looks_like_financial_year_matches_only_canonical_formats():
     assert _looks_like_financial_year("2024-25") is True
     assert _looks_like_financial_year("2025-26") is True
     assert _looks_like_financial_year("2024-2025") is False


### PR DESCRIPTION
Add templating functionality (and tests) for non-VRE new entrant connection costs. Includes:
- Created manual table ``connection_capacity_non_vre`` -> currently saved in ``manually_extracted_template_tables/7.5`` but open to moving elsewhere as its function is slightly different to other manual tables. To manage this I've just manually popped the read-in df out of manual table dict and into IASR table dict - again open to suggestions/other preferences for handling
- Regional granularity processing/filtering applied - non-VRE connection costs are given by technology and NEM region. Rows added for non-VRE defined in REZs (2, 4, 8hr batteries only atm)
- Some tweaks to overall flow that also touch VRE connection costs - tests and functions updated accordingly (primarily: no longer passing full ``*_new_entrant`` tables to the orchestrator functions, rather pre-processing to only pass necessary data through)

There are still a few notes that point to open discussions or might need addressing but at this point felt non-urgent and easier to come back to once we are a few steps further into validation and consensus with #103 . 

If I can also request in particular feedback on some of the tests - I don't know if I've done a great job on covering all necessary cases without too much double up so if anything sticks out as particularly unnecessary/messy or could be handled more clearly please let me know and I'll fix :) 