### PR TITLE
Rename the transmission default limit config field

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -213,10 +213,10 @@ Examples:
 
 ```rezs: discrete_nodes```
 
-### network.rez_to_sub_region_transmission_default_limit
+### network.transmission_default_limit
 
-Link capacity limit for rez to node connections that have their limit's modelled
-through custom constraint (MW).
+Default transmission capacity limit (MW) applied to a path with no explicit limit
+in the inputs.
 
 The export limits for some REZs are modelled via custom constraints which
 incorporate multiple transmission line flows and/or generator dispatch levels. For these
@@ -226,7 +226,7 @@ export limit.
 
 Examples:
 
-```rez_to_sub_region_transmission_default_limit: 1e5```
+```transmission_default_limit: 1e5```
 
 ## Temporal
 

--- a/docs/ispypsa_runs/new_test_run/ispypsa_config.yaml
+++ b/docs/ispypsa_runs/new_test_run/ispypsa_config.yaml
@@ -68,9 +68,9 @@ network:
     #   "discrete_nodes": REZs are added as network nodes to model REZ transmission limits
     #   "attached_to_parent_node": REZ resources are attached to their parent node (sub-region or NEM region)
     rezs: discrete_nodes
-  # Line capacity limit for rez to node connections that have their limit's modelled
-  # through custom constraint (MW).
-  rez_to_sub_region_transmission_default_limit: 1e5
+  # Default transmission capacity limit (MW) for a path with no explicit limit in
+  # the inputs (e.g. REZ connections whose limit is modelled via custom constraints).
+  transmission_default_limit: 1e5
 temporal:
   year_type: fy
   range:

--- a/docs/method.md
+++ b/docs/method.md
@@ -75,7 +75,7 @@ both directions of flow:
 `renewable_energy_zones` is used to set power flow limit.
 - TODO: Implement time varying export limits making use of the peak demand and
 winter limits provided in the IASR workbook.
-- If a NA or blank value is provided then the `rez_to_sub_region_transmission_default_limit`
+- If a NA or blank value is provided then the `transmission_default_limit`
 from the config file is used to set the limit. This is typically set to high value (1e5). Using
 the default limit is done for REZs where [custom contraints](#custom-constraints) are used to
 model REZ export limits, such that the static limit will not influence the optimisation.

--- a/ispypsa_config.yaml
+++ b/ispypsa_config.yaml
@@ -83,9 +83,9 @@ network:
     # Whether Renewable Energy Zones (REZs) are modelled as distinct nodes
     # Only discrete_nodes implemented
     rezs: discrete_nodes
-  # Line capacity limit for rez to node connections that have their limit's modelled
-  # through custom constraint (MW).
-  rez_to_sub_region_transmission_default_limit: 1e5
+  # Default transmission capacity limit (MW) for a path with no explicit limit in
+  # the inputs (e.g. REZ connections whose limit is modelled via custom constraints).
+  transmission_default_limit: 1e5
 
 
 # ===== Temporal =======================================================================

--- a/ispypsa_config_dev.yaml
+++ b/ispypsa_config_dev.yaml
@@ -83,9 +83,9 @@ network:
     # Whether Renewable Energy Zones (REZs) are modelled as distinct nodes
     # Only discrete_nodes implemented
     rezs: discrete_nodes
-  # Line capacity limit for rez to node connections that have their limit's modelled
-  # through custom constraint (MW).
-  rez_to_sub_region_transmission_default_limit: 1e5
+  # Default transmission capacity limit (MW) for a path with no explicit limit in
+  # the inputs (e.g. REZ connections whose limit is modelled via custom constraints).
+  transmission_default_limit: 1e5
 
 
 # ===== Temporal =======================================================================

--- a/src/ispypsa/config/validators.py
+++ b/src/ispypsa/config/validators.py
@@ -44,7 +44,7 @@ class NetworkConfig(BaseModel):
     annuitisation_lifetime: int
     transmission_expansion: bool
     rez_transmission_expansion: bool
-    rez_to_sub_region_transmission_default_limit: float
+    transmission_default_limit: float
 
 
 class TemporalAggregationConfig(BaseModel):

--- a/src/ispypsa/translator/renewable_energy_zones.py
+++ b/src/ispypsa/translator/renewable_energy_zones.py
@@ -27,7 +27,7 @@ def _translate_renewable_energy_zone_build_limits_to_links(
     # Create existing links from renewable energy zone build limits
     existing_links = _translate_existing_rez_connections_to_links(
         renewable_energy_zone_build_limits,
-        config.network.rez_to_sub_region_transmission_default_limit,
+        config.network.transmission_default_limit,
         config.temporal.range.start_year,
     )
 
@@ -62,7 +62,7 @@ def _translate_renewable_energy_zone_build_limits_to_links(
 
 def _translate_existing_rez_connections_to_links(
     renewable_energy_zone_build_limits: pd.DataFrame,
-    rez_to_sub_region_transmission_default_limit: float,
+    transmission_default_limit: float,
     start_year: int,
 ) -> pd.DataFrame:
     """Process existing REZ connection limits to PyPSA links.
@@ -70,7 +70,7 @@ def _translate_existing_rez_connections_to_links(
     Args:
         renewable_energy_zone_build_limits: `ISPyPSA` formatted pd.DataFrame detailing
             Renewable Energy Zone transmission limits.
-        rez_to_sub_region_transmission_default_limit: float specifying the transmission
+        transmission_default_limit: float specifying the transmission
             limit to use for rez to subregion connections when an explicit limit
             is not given in the inputs.
 
@@ -86,7 +86,7 @@ def _translate_existing_rez_connections_to_links(
     # custom constraints are given a very large capacity
     links["isp_type"] = "rez"
     links.loc[links["p_nom"].isna(), "isp_type"] = "rez_no_limit"
-    links["p_nom"] = links["p_nom"].fillna(rez_to_sub_region_transmission_default_limit)
+    links["p_nom"] = links["p_nom"].fillna(transmission_default_limit)
 
     links["p_min_pu"] = -1.0
     links["build_year"] = start_year - 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,7 @@ def sample_model_config():
             annuitisation_lifetime=25,
             transmission_expansion=True,
             rez_transmission_expansion=True,
-            rez_to_sub_region_transmission_default_limit=1000000.0,
+            transmission_default_limit=1000000.0,
         ),
         unserved_energy=UnservedEnergyConfig(cost=10000, max_per_node=10000),
     )

--- a/tests/test_cli/cli_test_helpers.py
+++ b/tests/test_cli/cli_test_helpers.py
@@ -146,7 +146,7 @@ def build_mock_config(
             "nodes": {"regional_granularity": granularity, "rezs": "discrete_nodes"},
             "transmission_expansion_limit_override": None,
             "rez_connection_expansion_limit_override": None,
-            "rez_to_sub_region_transmission_default_limit": 1e6,
+            "transmission_default_limit": 1e6,
         },
         "temporal": {
             "year_type": "fy",
@@ -329,7 +329,7 @@ def create_config_with_granularity(tmp_path, mock_workbook_file, granularity):
             "nodes": {"regional_granularity": granularity, "rezs": "discrete_nodes"},
             "transmission_expansion_limit_override": None,
             "rez_connection_expansion_limit_override": None,
-            "rez_to_sub_region_transmission_default_limit": 1e6,
+            "transmission_default_limit": 1e6,
         },
         "temporal": {
             "year_type": "fy",

--- a/tests/test_config/test_pydantic_model_config.py
+++ b/tests/test_config/test_pydantic_model_config.py
@@ -71,7 +71,7 @@ def get_valid_config():
                 "regional_granularity": "sub_regions",
                 "rezs": "discrete_nodes",
             },
-            "rez_to_sub_region_transmission_default_limit": 1e6,
+            "transmission_default_limit": 1e6,
         },
         "temporal": {
             "year_type": "fy",
@@ -167,7 +167,7 @@ def invalid_rez_transmission_expansion(config):
 
 
 def invalid_rez_transmission_limit(config):
-    config["network"]["rez_to_sub_region_transmission_default_limit"] = "help"
+    config["network"]["transmission_default_limit"] = "help"
     return config, ValidationError
 
 

--- a/tests/test_translator/ispypsa_config.yaml
+++ b/tests/test_translator/ispypsa_config.yaml
@@ -58,9 +58,9 @@ network:
     #   "discrete_nodes": REZs are added as network nodes to model REZ transmission limits
     #   "attached_to_parent_node": REZ resources are attached to their parent node (sub-region or NEM region)
     rezs: discrete_nodes
-  # Line capacity limit for rez to node connections that have their limit's modelled
-  # through custom constraint (MW).
-  rez_to_sub_region_transmission_default_limit: 1e5
+  # Default transmission capacity limit (MW) for a path with no explicit limit in
+  # the inputs (e.g. REZ connections whose limit is modelled via custom constraints).
+  transmission_default_limit: 1e5
 temporal:
   year_type: fy
   range:

--- a/tests/test_translator_and_model/test_limit_on_transmission_expansion.py
+++ b/tests/test_translator_and_model/test_limit_on_transmission_expansion.py
@@ -62,7 +62,7 @@ def test_flow_path_expansion_limit_respected(csv_str_to_df, tmp_path, monkeypatc
                 "regional_granularity": "sub_regions",
                 "rezs": "attached_to_parent_node",
             },
-            "rez_to_sub_region_transmission_default_limit": 1e5,
+            "transmission_default_limit": 1e5,
         },
         "temporal": {
             "year_type": "fy",

--- a/tests/test_translator_and_model/test_time_varying_flow_path_costs.py
+++ b/tests/test_translator_and_model/test_time_varying_flow_path_costs.py
@@ -58,7 +58,7 @@ def test_link_expansion_economic_timing(csv_str_to_df, tmp_path, monkeypatch):
                 "regional_granularity": "sub_regions",
                 "rezs": "attached_to_parent_node",
             },
-            "rez_to_sub_region_transmission_default_limit": 1e5,
+            "transmission_default_limit": 1e5,
         },
         "temporal": {
             "year_type": "fy",

--- a/tests/test_translator_and_model/test_vre_build_limit_custom_constraints.py
+++ b/tests/test_translator_and_model/test_vre_build_limit_custom_constraints.py
@@ -63,7 +63,7 @@ def test_vre_build_limit_constraint(csv_str_to_df, tmp_path, monkeypatch):
                 "regional_granularity": "sub_regions",
                 "rezs": "discrete_nodes",
             },
-            "rez_to_sub_region_transmission_default_limit": 1e5,
+            "transmission_default_limit": 1e5,
         },
         "temporal": {
             "year_type": "fy",


### PR DESCRIPTION
`rez_to_sub_region_transmission_default_limit` becomes `transmission_default_limit`.

Under the new-format translator (#126) the default applies to any transmission path without limit data, not just REZ connections, so the old name no longer describes its scope. The rename is peeled out of #126 to keep that PR focused on the translation; this one is a mechanical find-and-replace across the config model, config files, docs and tests.

Breaking for existing config files: the field needs renaming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
