### PR TITLE
Re-sequence new-format timeslice patterns onto snapshots

### DIFF
--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -1,0 +1,240 @@
+"""Re-sequences the timeslice patterns and maps them onto model snapshots.
+
+The templated ``timeslices`` table gives one month-day window pattern per
+reference (weather) year. This module assigns a reference year to each model
+financial year using the configured reference_year_cycle — the identical
+assignment the trace pipeline uses, so timeslices stay consistent with the
+demand and VRE traces — expands the assigned patterns into absolute date
+windows, and joins them onto the model's snapshots. The resulting mapping is
+what pypsa_build uses to expand per-timeslice link limits into series and to
+restrict custom constraints to the snapshots their RHS values apply to.
+"""
+
+import calendar
+import logging
+
+import pandas as pd
+from isp_trace_parser import construct_reference_year_mapping
+
+from ispypsa.config import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+_TIMESLICE_SNAPSHOT_COLUMNS = ["timeslice_id", "investment_periods", "snapshots"]
+
+
+def _create_timeslice_snapshot_mapping(
+    timeslices: pd.DataFrame, snapshots: pd.DataFrame, config: ModelConfig
+) -> pd.DataFrame:
+    """Maps each snapshot to the timeslices active on its date under the
+    configured reference_year_cycle.
+
+    I/O Example:
+        timeslices:
+            timeslice_id     reference_year  start_month_day  end_month_day
+            nsw_peak_demand  2018            01-13            01-14
+            vic_peak_demand  2018            01-20            01-21  # no snapshots inside
+
+        snapshots (config: start_year 2025, reference_year_cycle [2018]):
+            investment_periods  snapshots
+            2025                2025-01-13 12:00:00
+            2025                2025-01-15 12:00:00
+
+        returns:
+            timeslice_id     investment_periods  snapshots
+            nsw_peak_demand  2025                2025-01-13 12:00:00
+    """
+    if config.temporal.year_type != "fy":
+        raise NotImplementedError(
+            "Timeslice re-sequencing is only implemented for fy year_type; "
+            "AEMO's timeslice calendar is built on financial years."
+        )
+    if timeslices.empty:
+        return pd.DataFrame(columns=_TIMESLICE_SNAPSHOT_COLUMNS)
+    reference_year_mapping = _map_model_years_to_reference_years(config)
+    _raise_on_reference_years_without_patterns(reference_year_mapping, timeslices)
+    windows = _expand_patterns_to_absolute_windows(timeslices, reference_year_mapping)
+    mapped = [
+        _snapshots_in_window(snapshots, window) for window in windows.itertuples()
+    ]
+    return _concat_window_snapshots(mapped)
+
+
+def _map_model_years_to_reference_years(config: ModelConfig) -> dict[int, int]:
+    """The model-year -> reference-year assignment, via the identical
+    construct_reference_year_mapping call the trace pipeline makes, plus the
+    year before the first model year (cycle-consistent: the cycle's last
+    reference year precedes its first) so windows starting in the prior
+    financial year — winter runs April to October — cover the first model
+    year's July-September snapshots.
+
+    I/O Example:
+        start_year 2025, end_year 2027, reference_year_cycle [2011, 2018]
+        -> {2024: 2018, 2025: 2011, 2026: 2018, 2027: 2011}
+    """
+    cycle = config.temporal.capacity_expansion.reference_year_cycle
+    mapping = construct_reference_year_mapping(
+        start_year=config.temporal.range.start_year,
+        end_year=config.temporal.range.end_year,
+        reference_years=cycle,
+    )
+    return {config.temporal.range.start_year - 1: cycle[-1], **mapping}
+
+
+def _raise_on_reference_years_without_patterns(
+    reference_year_mapping: dict[int, int], timeslices: pd.DataFrame
+) -> None:
+    """Raise if the configured cycle uses reference years the timeslices
+    table has no patterns for — silently producing no windows would let
+    timeslice-tagged limits and constraints never bind."""
+    missing = sorted(
+        set(reference_year_mapping.values()) - set(timeslices["reference_year"])
+    )
+    if missing:
+        raise ValueError(
+            f"Configured reference_year_cycle includes reference years with "
+            f"no timeslice window patterns: {missing}"
+        )
+
+
+def _expand_patterns_to_absolute_windows(
+    timeslices: pd.DataFrame, reference_year_mapping: dict[int, int]
+) -> pd.DataFrame:
+    """Expands each model year's assigned pattern into absolute date windows.
+
+    I/O Example:
+        timeslices:
+            timeslice_id     reference_year  start_month_day  end_month_day
+            nsw_peak_demand  2018            11-18            11-20
+
+        reference_year_mapping {2026: 2018} ->
+            timeslice_id     start_date  end_date
+            nsw_peak_demand  2025-11-18  2025-11-20
+    """
+    expanded = []
+    for model_year, reference_year in reference_year_mapping.items():
+        pattern = timeslices[timeslices["reference_year"] == reference_year]
+        expanded.append(_place_pattern_in_financial_year(pattern, model_year))
+    return pd.concat(expanded, ignore_index=True)
+
+
+def _place_pattern_in_financial_year(
+    pattern: pd.DataFrame, model_year: int
+) -> pd.DataFrame:
+    """Turns one pattern's month-day windows into absolute dates in the
+    financial year ending model_year: starts in July-December land in
+    model_year - 1, January-June in model_year, and each end is its first
+    occurrence after the start (ends may fall past 30 June, e.g. winter
+    April-October).
+
+    I/O Example (model_year=2026):
+        timeslice_id          start_month_day  end_month_day
+        nsw_peak_demand       11-18            11-20
+        nsw_summer_typical    11-20            03-20  # end wraps past new year
+        nsw_winter_reference  04-01            10-01  # end past 30 June
+
+        returns:
+            timeslice_id          start_date  end_date
+            nsw_peak_demand       2025-11-18  2025-11-20
+            nsw_summer_typical    2025-11-20  2026-03-20
+            nsw_winter_reference  2026-04-01  2026-10-01
+    """
+    placed = pattern.copy()
+    placed["start_date"] = placed["start_month_day"].apply(
+        lambda month_day: _place_start_in_financial_year(month_day, model_year)
+    )
+    placed["end_date"] = placed.apply(
+        lambda row: _resolve_end_date(
+            row["end_month_day"], row["start_month_day"], row["start_date"]
+        ),
+        axis=1,
+    )
+    return placed[["timeslice_id", "start_date", "end_date"]]
+
+
+def _place_start_in_financial_year(month_day: str, model_year: int) -> pd.Timestamp:
+    """'11-18' in FY2026 -> 2025-11-18; '04-01' in FY2026 -> 2026-04-01."""
+    month = int(month_day.split("-")[0])
+    year = model_year - 1 if month >= 7 else model_year
+    return _timestamp_with_leap_day_clamp(year, month_day)
+
+
+def _resolve_end_date(
+    end_month_day: str, start_month_day: str, start: pd.Timestamp
+) -> pd.Timestamp:
+    """An end later in the calendar year than the start lands in the start's
+    year; otherwise it wraps into the next. The comparison uses the original
+    month-day strings (which compare lexically in chronological order)
+    rather than the placed dates, so leap-day clamping a one-day 02-28 to
+    02-29 window in a non-leap year collapses it to an empty window instead
+    of wrapping its end a year out.
+
+    I/O Example:
+        ('03-20', '11-18', 2025-11-18) -> 2026-03-20  # wraps
+        ('10-01', '04-01', 2026-04-01) -> 2026-10-01
+        ('02-29', '02-28', 2025-02-28) -> 2025-02-28  # clamped: empty window
+    """
+    year = start.year if end_month_day > start_month_day else start.year + 1
+    return _timestamp_with_leap_day_clamp(year, end_month_day)
+
+
+def _timestamp_with_leap_day_clamp(year: int, month_day: str) -> pd.Timestamp:
+    """'02-29' is clamped to 28 February in non-leap years — patterns from
+    leap reference years land in non-leap model years under re-sequencing.
+
+    I/O Example:
+        (2025, '02-29') -> 2025-02-28; (2024, '02-29') -> 2024-02-29
+    """
+    month, day = (int(part) for part in month_day.split("-"))
+    if (month, day) == (2, 29) and not calendar.isleap(year):
+        day = 28
+    return pd.Timestamp(year=year, month=month, day=day)
+
+
+def _snapshots_in_window(snapshots: pd.DataFrame, window) -> pd.DataFrame:
+    """Selects the snapshots inside one window, tagged with its timeslice.
+
+    I/O Example:
+        snapshots 2025-01-13 12:00 and 2025-01-15 12:00,
+        window nsw_peak_demand [2025-01-13, 2025-01-14)
+        -> the 2025-01-13 12:00 snapshot tagged nsw_peak_demand
+    """
+    in_window = (snapshots["snapshots"] >= window.start_date) & (
+        snapshots["snapshots"] < window.end_date
+    )
+    tagged = snapshots.loc[in_window, ["investment_periods", "snapshots"]].copy()
+    tagged["timeslice_id"] = window.timeslice_id
+    return tagged
+
+
+def _concat_window_snapshots(mapped: list[pd.DataFrame]) -> pd.DataFrame:
+    """Combines the per-window snapshot selections into one mapping table."""
+    if not mapped:
+        return pd.DataFrame(columns=_TIMESLICE_SNAPSHOT_COLUMNS)
+    mapping = pd.concat(mapped, ignore_index=True)
+    return mapping.loc[:, _TIMESLICE_SNAPSHOT_COLUMNS]
+
+
+def _log_referenced_timeslices_without_snapshots(
+    timeslice_snapshots: pd.DataFrame,
+    link_timeslice_limits: pd.DataFrame,
+    custom_constraints_rhs: pd.DataFrame,
+) -> None:
+    """Logs the timeslices referenced by a limit or constraint but mapped to
+    no snapshots — those limits and constraints will never apply.
+
+    This is expected when snapshot aggregation (e.g. representative weeks)
+    selects no snapshots inside a timeslice's windows, and for calendar
+    timeslices that never activate (tas_peak_demand in the Draft 2026 ISP
+    calendar), but the user should know the affected inputs will not bind.
+    """
+    referenced = set(link_timeslice_limits["timeslice"]) | set(
+        custom_constraints_rhs["timeslice"].dropna()
+    )
+    without_snapshots = referenced - set(timeslice_snapshots["timeslice_id"])
+    if without_snapshots:
+        logger.warning(
+            f"Timeslices referenced by transmission limits or custom constraints "
+            f"but with no snapshots in the model (these limits and constraints "
+            f"will never apply): {sorted(without_snapshots)}"
+        )

--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -20,7 +20,7 @@ def _create_timeslice_snapshot_mapping(
 
     Mapping is done on a model year by model year basis:
         - Each model year is mapped to a reference year.
-        - Then the timeslice windows for that reference year are used map each
+        - Then the timeslice windows for that reference year are used to map each
           snapshot to a timeslice_id.
 
     I/O Example:

--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -19,9 +19,9 @@ def _create_timeslice_snapshot_mapping(
     VRE traces use).
 
     I/O Example:
-        timeslices (each year's windows tile its financial year: summer opens
-        in November and wraps past New Year, a peak day interrupts it, summer
-        resumes to April, then winter runs April to November, crossing 30
+        timeslices (each year's windows tile (cover in full) its financial year:
+        summer opens in November and wraps past New Year, a peak day interrupts it,
+        summer resumes to April, then winter runs April to November, crossing 30
         June into the next financial year):
             timeslice_id          reference_year  start_month_day  end_month_day
             nsw_summer_typical    2011            11-01            01-31
@@ -54,10 +54,7 @@ def _create_timeslice_snapshot_mapping(
             nsw_peak_demand       2026                2026-01-07 12:00:00
             nsw_summer_typical    2026                2026-01-31 12:00:00
     """
-    if timeslices.empty:
-        return pd.DataFrame(columns=_TIMESLICE_SNAPSHOT_COLUMNS)
     reference_year_mapping = _map_model_years_to_reference_years(config)
-    _raise_on_reference_years_without_patterns(reference_year_mapping, timeslices)
     snapshots = _add_interval_model_year_and_month_day(
         snapshots, config.temporal.year_type
     )
@@ -86,29 +83,13 @@ def _map_model_years_to_reference_years(config: ModelConfig) -> dict[int, int]:
     )
 
 
-def _raise_on_reference_years_without_patterns(
-    reference_year_mapping: dict[int, int], timeslices: pd.DataFrame
-) -> None:
-    """Raise if the configured cycle uses reference years the timeslices
-    table has no patterns for — silently producing no windows would let
-    timeslice-tagged limits and constraints never bind."""
-    missing = sorted(
-        set(reference_year_mapping.values()) - set(timeslices["reference_year"])
-    )
-    if missing:
-        raise ValueError(
-            f"Configured reference_year_cycle includes reference years with "
-            f"no timeslice window patterns: {missing}"
-        )
-
-
 def _add_interval_model_year_and_month_day(
     snapshots: pd.DataFrame, year_type: str
 ) -> pd.DataFrame:
-    """Adds the model year and month-day of the interval each snapshot stands
-    for. Snapshots are stamped with the interval's end time, so both are read
-    off the interval's last instant, one second before the stamp: a stamp of
-    exactly midnight belongs to the day (and year) just ended.
+    """Adds the model year and month-day for each snapshot. Snapshots are stamped
+    with the interval's end time, so both are read off the interval's last instant, one
+    second before the stamp: a stamp of exactly midnight belongs to the day (and year)
+    just ended.
 
     I/O Example (year_type fy):
         investment_periods  snapshots
@@ -135,7 +116,9 @@ def _tag_snapshots_with_pattern(
     snapshots: pd.DataFrame, pattern: pd.DataFrame
 ) -> pd.DataFrame:
     """Tags one model year's snapshots with the timeslice whose window their
-    month-day falls in.
+    month-day falls in, by pairing every snapshot with every window and
+    keeping the pairs where the month-day lies in the window. A pattern
+    with no windows tags nothing.
 
     I/O Example:
         snapshots (FY2026, month_day already added):
@@ -151,39 +134,34 @@ def _tag_snapshots_with_pattern(
             nsw_winter_reference  04-01            11-01
 
         returns:
-            investment_periods  snapshots            timeslice_id
-            2026                2026-01-07 12:00:00  nsw_peak_demand
-            2026                2025-08-15 12:00:00  nsw_winter_reference
+            timeslice_id          investment_periods  snapshots
+            nsw_winter_reference  2026                2025-08-15 12:00:00
+            nsw_peak_demand       2026                2026-01-07 12:00:00
     """
-    tagged = [
-        _snapshots_in_window(snapshots, window) for window in pattern.itertuples()
-    ]
-    return pd.concat(tagged)
+    pairs = snapshots.merge(pattern, how="cross")
+    in_window = _month_day_in_window(
+        pairs["month_day"], pairs["start_month_day"], pairs["end_month_day"]
+    )
+    return pairs.loc[in_window, _TIMESLICE_SNAPSHOT_COLUMNS]
 
 
-def _snapshots_in_window(snapshots: pd.DataFrame, window) -> pd.DataFrame:
-    """Selects the snapshots whose month-day lies in one window, tagged with
-    its timeslice. A window whose end is at or before its start wraps past
-    New Year.
+def _month_day_in_window(
+    month_day: pd.Series, start: pd.Series, end: pd.Series
+) -> pd.Series:
+    """Element-wise: is month_day in the [start, end) month-day window? A
+    window whose end is at or before its start wraps past New Year.
 
     I/O Example:
-        snapshots:
-            investment_periods  snapshots            month_day
-            2026                2025-12-15 12:00:00  12-15
-            2026                2026-01-07 12:00:00  01-07  # equals end: excluded
-
-        window nsw_summer_typical 11-01 -> 01-07 (wraps) ->
-            investment_periods  snapshots            timeslice_id
-            2026                2025-12-15 12:00:00  nsw_summer_typical
+        month_day  start  end    ->
+        12-15      11-01  01-07  True   # wraps: after start
+        01-07      11-01  01-07  False  # equals end: excluded
+        01-07      01-07  01-08  True
+        08-15      04-01  11-01  True
     """
-    month_day = snapshots["month_day"]
-    after_start = month_day >= window.start_month_day
-    before_end = month_day < window.end_month_day
-    wraps = window.end_month_day <= window.start_month_day
-    in_window = (after_start | before_end) if wraps else (after_start & before_end)
-    tagged = snapshots.loc[in_window, ["investment_periods", "snapshots"]].copy()
-    tagged["timeslice_id"] = window.timeslice_id
-    return tagged
+    after_start = month_day >= start
+    before_end = month_day < end
+    wraps = end <= start
+    return (after_start | before_end).where(wraps, after_start & before_end)
 
 
 def _concat_tagged_snapshots(mapped: list[pd.DataFrame]) -> pd.DataFrame:

--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -165,8 +165,10 @@ def _month_day_in_window(
     """
     after_start = month_day >= start
     before_end = month_day < end
+    in_plain_window = after_start & before_end
+    in_wrapping_window = after_start | before_end
     wraps = end <= start
-    return (after_start | before_end).where(wraps, after_start & before_end)
+    return (~wraps & in_plain_window) | (wraps & in_wrapping_window)
 
 
 def _concat_tagged_snapshots(mapped: list[pd.DataFrame]) -> pd.DataFrame:

--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -1,16 +1,3 @@
-"""Re-sequences the timeslice patterns and maps them onto model snapshots.
-
-The templated ``timeslices`` table gives one month-day window pattern per
-reference (weather) year. This module assigns a reference year to each model
-financial year using the configured reference_year_cycle — the identical
-assignment the trace pipeline uses, so timeslices stay consistent with the
-demand and VRE traces — expands the assigned patterns into absolute date
-windows, and joins them onto the model's snapshots. The resulting mapping is
-what pypsa_build uses to expand per-timeslice link limits into series and to
-restrict custom constraints to the snapshots their RHS values apply to.
-"""
-
-import calendar
 import logging
 
 import pandas as pd
@@ -26,59 +13,77 @@ _TIMESLICE_SNAPSHOT_COLUMNS = ["timeslice_id", "investment_periods", "snapshots"
 def _create_timeslice_snapshot_mapping(
     timeslices: pd.DataFrame, snapshots: pd.DataFrame, config: ModelConfig
 ) -> pd.DataFrame:
-    """Maps each snapshot to the timeslices active on its date under the
-    configured reference_year_cycle.
+    """Maps each snapshot to the timeslice active on its date, using the
+    window pattern of the reference year the configured reference_year_cycle
+    assigns to the snapshot's model year (the same assignment the demand and
+    VRE traces use).
 
     I/O Example:
-        timeslices:
-            timeslice_id     reference_year  start_month_day  end_month_day
-            nsw_peak_demand  2018            01-13            01-14
-            vic_peak_demand  2018            01-20            01-21  # no snapshots inside
+        timeslices (each year's windows tile its financial year: summer opens
+        in November and wraps past New Year, a peak day interrupts it, summer
+        resumes to April, then winter runs April to November, crossing 30
+        June into the next financial year):
+            timeslice_id          reference_year  start_month_day  end_month_day
+            nsw_summer_typical    2011            11-01            01-31
+            nsw_peak_demand       2011            01-31            02-02
+            nsw_summer_typical    2011            02-02            04-01
+            nsw_winter_reference  2011            04-01            11-01
+            nsw_summer_typical    2018            11-01            01-07
+            nsw_peak_demand       2018            01-07            01-08
+            nsw_summer_typical    2018            01-08            04-01
+            nsw_winter_reference  2018            04-01            11-01
 
-        snapshots (config: start_year 2025, reference_year_cycle [2018]):
+        snapshots:
             investment_periods  snapshots
-            2025                2025-01-13 12:00:00
-            2025                2025-01-15 12:00:00
+            2025                2024-08-15 12:00:00  # winter's tail at the FY start
+            2025                2025-01-20 12:00:00
+            2025                2025-01-31 12:00:00  # summer ended 01-31 00:00: peak
+            2026                2026-01-07 12:00:00
+            2026                2026-01-31 12:00:00  # 2011 peak dates; summer in 2018
+
+        config:
+            year_type fy, start_year 2025, end_year 2026,
+            reference_year_cycle [2011, 2018]
+            -> FY2025 uses 2011's pattern, FY2026 uses 2018's
 
         returns:
-            timeslice_id     investment_periods  snapshots
-            nsw_peak_demand  2025                2025-01-13 12:00:00
+            timeslice_id          investment_periods  snapshots
+            nsw_winter_reference  2025                2024-08-15 12:00:00
+            nsw_summer_typical    2025                2025-01-20 12:00:00
+            nsw_peak_demand       2025                2025-01-31 12:00:00
+            nsw_peak_demand       2026                2026-01-07 12:00:00
+            nsw_summer_typical    2026                2026-01-31 12:00:00
     """
-    if config.temporal.year_type != "fy":
-        raise NotImplementedError(
-            "Timeslice re-sequencing is only implemented for fy year_type; "
-            "AEMO's timeslice calendar is built on financial years."
-        )
     if timeslices.empty:
         return pd.DataFrame(columns=_TIMESLICE_SNAPSHOT_COLUMNS)
     reference_year_mapping = _map_model_years_to_reference_years(config)
     _raise_on_reference_years_without_patterns(reference_year_mapping, timeslices)
-    windows = _expand_patterns_to_absolute_windows(timeslices, reference_year_mapping)
+    snapshots = _add_interval_model_year_and_month_day(
+        snapshots, config.temporal.year_type
+    )
     mapped = [
-        _snapshots_in_window(snapshots, window) for window in windows.itertuples()
+        _tag_snapshots_with_pattern(
+            snapshots[snapshots["model_year"] == model_year],
+            timeslices[timeslices["reference_year"] == reference_year],
+        )
+        for model_year, reference_year in reference_year_mapping.items()
     ]
-    return _concat_window_snapshots(mapped)
+    return _concat_tagged_snapshots(mapped)
 
 
 def _map_model_years_to_reference_years(config: ModelConfig) -> dict[int, int]:
     """The model-year -> reference-year assignment, via the identical
-    construct_reference_year_mapping call the trace pipeline makes, plus the
-    year before the first model year (cycle-consistent: the cycle's last
-    reference year precedes its first) so windows starting in the prior
-    financial year — winter runs April to October — cover the first model
-    year's July-September snapshots.
+    construct_reference_year_mapping call the trace pipeline makes.
 
     I/O Example:
         start_year 2025, end_year 2027, reference_year_cycle [2011, 2018]
-        -> {2024: 2018, 2025: 2011, 2026: 2018, 2027: 2011}
+        -> {2025: 2011, 2026: 2018, 2027: 2011}
     """
-    cycle = config.temporal.capacity_expansion.reference_year_cycle
-    mapping = construct_reference_year_mapping(
+    return construct_reference_year_mapping(
         start_year=config.temporal.range.start_year,
         end_year=config.temporal.range.end_year,
-        reference_years=cycle,
+        reference_years=config.temporal.capacity_expansion.reference_year_cycle,
     )
-    return {config.temporal.range.start_year - 1: cycle[-1], **mapping}
 
 
 def _raise_on_reference_years_without_patterns(
@@ -97,121 +102,95 @@ def _raise_on_reference_years_without_patterns(
         )
 
 
-def _expand_patterns_to_absolute_windows(
-    timeslices: pd.DataFrame, reference_year_mapping: dict[int, int]
+def _add_interval_model_year_and_month_day(
+    snapshots: pd.DataFrame, year_type: str
 ) -> pd.DataFrame:
-    """Expands each model year's assigned pattern into absolute date windows.
+    """Adds the model year and month-day of the interval each snapshot stands
+    for. Snapshots are stamped with the interval's end time, so both are read
+    off the interval's last instant, one second before the stamp: a stamp of
+    exactly midnight belongs to the day (and year) just ended.
+
+    I/O Example (year_type fy):
+        investment_periods  snapshots
+        2026                2025-07-01 00:00:00  # last interval of FY2025
+        2026                2025-11-01 00:00:00  # last interval of 31 October
+        2026                2025-11-01 00:30:00
+
+        ->
+        investment_periods  snapshots            model_year  month_day
+        2026                2025-07-01 00:00:00  2025        06-30
+        2026                2025-11-01 00:00:00  2026        10-31
+        2026                2025-11-01 00:30:00  2026        11-01
+    """
+    last_instant = snapshots["snapshots"] - pd.Timedelta(seconds=1)
+    snapshots = snapshots.copy()
+    snapshots["model_year"] = last_instant.dt.year
+    if year_type == "fy":
+        snapshots["model_year"] += (last_instant.dt.month >= 7).astype(int)
+    snapshots["month_day"] = last_instant.dt.strftime("%m-%d")
+    return snapshots
+
+
+def _tag_snapshots_with_pattern(
+    snapshots: pd.DataFrame, pattern: pd.DataFrame
+) -> pd.DataFrame:
+    """Tags one model year's snapshots with the timeslice whose window their
+    month-day falls in.
 
     I/O Example:
-        timeslices:
-            timeslice_id     reference_year  start_month_day  end_month_day
-            nsw_peak_demand  2018            11-18            11-20
+        snapshots (FY2026, month_day already added):
+            investment_periods  snapshots            month_day
+            2026                2025-08-15 12:00:00  08-15
+            2026                2026-01-07 12:00:00  01-07
 
-        reference_year_mapping {2026: 2018} ->
-            timeslice_id     start_date  end_date
-            nsw_peak_demand  2025-11-18  2025-11-20
-    """
-    expanded = []
-    for model_year, reference_year in reference_year_mapping.items():
-        pattern = timeslices[timeslices["reference_year"] == reference_year]
-        expanded.append(_place_pattern_in_financial_year(pattern, model_year))
-    return pd.concat(expanded, ignore_index=True)
-
-
-def _place_pattern_in_financial_year(
-    pattern: pd.DataFrame, model_year: int
-) -> pd.DataFrame:
-    """Turns one pattern's month-day windows into absolute dates in the
-    financial year ending model_year: starts in July-December land in
-    model_year - 1, January-June in model_year, and each end is its first
-    occurrence after the start (ends may fall past 30 June, e.g. winter
-    April-October).
-
-    I/O Example (model_year=2026):
-        timeslice_id          start_month_day  end_month_day
-        nsw_peak_demand       11-18            11-20
-        nsw_summer_typical    11-20            03-20  # end wraps past new year
-        nsw_winter_reference  04-01            10-01  # end past 30 June
+        pattern (reference year 2018):
+            timeslice_id          start_month_day  end_month_day
+            nsw_summer_typical    11-01            01-07
+            nsw_peak_demand       01-07            01-08
+            nsw_summer_typical    01-08            04-01
+            nsw_winter_reference  04-01            11-01
 
         returns:
-            timeslice_id          start_date  end_date
-            nsw_peak_demand       2025-11-18  2025-11-20
-            nsw_summer_typical    2025-11-20  2026-03-20
-            nsw_winter_reference  2026-04-01  2026-10-01
+            investment_periods  snapshots            timeslice_id
+            2026                2026-01-07 12:00:00  nsw_peak_demand
+            2026                2025-08-15 12:00:00  nsw_winter_reference
     """
-    placed = pattern.copy()
-    placed["start_date"] = placed["start_month_day"].apply(
-        lambda month_day: _place_start_in_financial_year(month_day, model_year)
-    )
-    placed["end_date"] = placed.apply(
-        lambda row: _resolve_end_date(
-            row["end_month_day"], row["start_month_day"], row["start_date"]
-        ),
-        axis=1,
-    )
-    return placed[["timeslice_id", "start_date", "end_date"]]
-
-
-def _place_start_in_financial_year(month_day: str, model_year: int) -> pd.Timestamp:
-    """'11-18' in FY2026 -> 2025-11-18; '04-01' in FY2026 -> 2026-04-01."""
-    month = int(month_day.split("-")[0])
-    year = model_year - 1 if month >= 7 else model_year
-    return _timestamp_with_leap_day_clamp(year, month_day)
-
-
-def _resolve_end_date(
-    end_month_day: str, start_month_day: str, start: pd.Timestamp
-) -> pd.Timestamp:
-    """An end later in the calendar year than the start lands in the start's
-    year; otherwise it wraps into the next. The comparison uses the original
-    month-day strings (which compare lexically in chronological order)
-    rather than the placed dates, so leap-day clamping a one-day 02-28 to
-    02-29 window in a non-leap year collapses it to an empty window instead
-    of wrapping its end a year out.
-
-    I/O Example:
-        ('03-20', '11-18', 2025-11-18) -> 2026-03-20  # wraps
-        ('10-01', '04-01', 2026-04-01) -> 2026-10-01
-        ('02-29', '02-28', 2025-02-28) -> 2025-02-28  # clamped: empty window
-    """
-    year = start.year if end_month_day > start_month_day else start.year + 1
-    return _timestamp_with_leap_day_clamp(year, end_month_day)
-
-
-def _timestamp_with_leap_day_clamp(year: int, month_day: str) -> pd.Timestamp:
-    """'02-29' is clamped to 28 February in non-leap years — patterns from
-    leap reference years land in non-leap model years under re-sequencing.
-
-    I/O Example:
-        (2025, '02-29') -> 2025-02-28; (2024, '02-29') -> 2024-02-29
-    """
-    month, day = (int(part) for part in month_day.split("-"))
-    if (month, day) == (2, 29) and not calendar.isleap(year):
-        day = 28
-    return pd.Timestamp(year=year, month=month, day=day)
+    tagged = [
+        _snapshots_in_window(snapshots, window) for window in pattern.itertuples()
+    ]
+    return pd.concat(tagged)
 
 
 def _snapshots_in_window(snapshots: pd.DataFrame, window) -> pd.DataFrame:
-    """Selects the snapshots inside one window, tagged with its timeslice.
+    """Selects the snapshots whose month-day lies in one window, tagged with
+    its timeslice. A window whose end is at or before its start wraps past
+    New Year.
 
     I/O Example:
-        snapshots 2025-01-13 12:00 and 2025-01-15 12:00,
-        window nsw_peak_demand [2025-01-13, 2025-01-14)
-        -> the 2025-01-13 12:00 snapshot tagged nsw_peak_demand
+        snapshots:
+            investment_periods  snapshots            month_day
+            2026                2025-12-15 12:00:00  12-15
+            2026                2026-01-07 12:00:00  01-07  # equals end: excluded
+
+        window nsw_summer_typical 11-01 -> 01-07 (wraps) ->
+            investment_periods  snapshots            timeslice_id
+            2026                2025-12-15 12:00:00  nsw_summer_typical
     """
-    in_window = (snapshots["snapshots"] >= window.start_date) & (
-        snapshots["snapshots"] < window.end_date
-    )
+    month_day = snapshots["month_day"]
+    after_start = month_day >= window.start_month_day
+    before_end = month_day < window.end_month_day
+    wraps = window.end_month_day <= window.start_month_day
+    in_window = (after_start | before_end) if wraps else (after_start & before_end)
     tagged = snapshots.loc[in_window, ["investment_periods", "snapshots"]].copy()
     tagged["timeslice_id"] = window.timeslice_id
     return tagged
 
 
-def _concat_window_snapshots(mapped: list[pd.DataFrame]) -> pd.DataFrame:
-    """Combines the per-window snapshot selections into one mapping table."""
-    if not mapped:
-        return pd.DataFrame(columns=_TIMESLICE_SNAPSHOT_COLUMNS)
+def _concat_tagged_snapshots(mapped: list[pd.DataFrame]) -> pd.DataFrame:
+    """Combines the per-model-year tagged snapshots into one mapping table,
+    in snapshot order."""
     mapping = pd.concat(mapped, ignore_index=True)
+    mapping = mapping.sort_values(["snapshots", "timeslice_id"]).reset_index(drop=True)
     return mapping.loc[:, _TIMESLICE_SNAPSHOT_COLUMNS]
 
 

--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -18,6 +18,11 @@ def _create_timeslice_snapshot_mapping(
     assigns to the snapshot's model year (the same assignment the demand and
     VRE traces use).
 
+    Mapping is done on a model year by model year basis:
+        - Each model year is mapped to a reference year.
+        - Then the timeslice windows for that reference year are used map each
+          snapshot to a timeslice_id.
+
     I/O Example:
         timeslices (each year's windows tile (cover in full) its financial year:
         summer opens in November and wraps past New Year, a peak day interrupts it,

--- a/src/ispypsa/translator/timeslices.py
+++ b/src/ispypsa/translator/timeslices.py
@@ -1,9 +1,6 @@
 import logging
 
 import pandas as pd
-from isp_trace_parser import construct_reference_year_mapping
-
-from ispypsa.config import ModelConfig
 
 logger = logging.getLogger(__name__)
 
@@ -11,12 +8,14 @@ _TIMESLICE_SNAPSHOT_COLUMNS = ["timeslice_id", "investment_periods", "snapshots"
 
 
 def _create_timeslice_snapshot_mapping(
-    timeslices: pd.DataFrame, snapshots: pd.DataFrame, config: ModelConfig
+    timeslices: pd.DataFrame,
+    snapshots: pd.DataFrame,
+    reference_year_mapping: dict[int, int],
+    year_type: str,
 ) -> pd.DataFrame:
     """Maps each snapshot to the timeslice active on its date, using the
-    window pattern of the reference year the configured reference_year_cycle
-    assigns to the snapshot's model year (the same assignment the demand and
-    VRE traces use).
+    window pattern of the reference year assigned to the snapshot's model
+    year.
 
     Mapping is done on a model year by model year basis:
         - Each model year is mapped to a reference year.
@@ -46,9 +45,7 @@ def _create_timeslice_snapshot_mapping(
             2026                2026-01-07 12:00:00
             2026                2026-01-31 12:00:00  # 2011 peak dates; summer in 2018
 
-        config:
-            year_type fy, start_year 2025, end_year 2026,
-            reference_year_cycle [2011, 2018]
+        reference_year_mapping {2025: 2011, 2026: 2018}, year_type "fy"
             -> FY2025 uses 2011's pattern, FY2026 uses 2018's
 
         returns:
@@ -59,10 +56,7 @@ def _create_timeslice_snapshot_mapping(
             nsw_peak_demand       2026                2026-01-07 12:00:00
             nsw_summer_typical    2026                2026-01-31 12:00:00
     """
-    reference_year_mapping = _map_model_years_to_reference_years(config)
-    snapshots = _add_interval_model_year_and_month_day(
-        snapshots, config.temporal.year_type
-    )
+    snapshots = _add_interval_model_year_and_month_day(snapshots, year_type)
     mapped = [
         _tag_snapshots_with_pattern(
             snapshots[snapshots["model_year"] == model_year],
@@ -71,21 +65,6 @@ def _create_timeslice_snapshot_mapping(
         for model_year, reference_year in reference_year_mapping.items()
     ]
     return _concat_tagged_snapshots(mapped)
-
-
-def _map_model_years_to_reference_years(config: ModelConfig) -> dict[int, int]:
-    """The model-year -> reference-year assignment, via the identical
-    construct_reference_year_mapping call the trace pipeline makes.
-
-    I/O Example:
-        start_year 2025, end_year 2027, reference_year_cycle [2011, 2018]
-        -> {2025: 2011, 2026: 2018, 2027: 2011}
-    """
-    return construct_reference_year_mapping(
-        start_year=config.temporal.range.start_year,
-        end_year=config.temporal.range.end_year,
-        reference_years=config.temporal.capacity_expansion.reference_year_cycle,
-    )
 
 
 def _add_interval_model_year_and_month_day(

--- a/src/ispypsa/validation/schemas/timeslices.yaml
+++ b/src/ispypsa/validation/schemas/timeslices.yaml
@@ -7,10 +7,8 @@ custom_validation:
     description: >
       Within a region (the timeslice_id prefix before the first underscore)
       and reference_year, no two windows may cover the same day. Windows are
-      compared as expanded [start, end) day ranges, not raw month-day strings:
-      an end_month_day at or before its start wraps into the following calendar
-      year (e.g. 11-20 to 03-20), and winter windows run past 30 June into the
-      next financial year (04-01 to 10-01).
+      compared as [start, end) month-day ranges where an end_month_day at or
+      before its start wraps past New Year (e.g. 11-20 to 03-20).
   - name: windows_cover_full_year_per_region_and_reference_year
     description: >
       Within a region (the timeslice_id prefix before the first underscore)
@@ -21,15 +19,27 @@ custom_validation:
       where the next begins and the last wraps to the first. A region need not
       use all three timeslice types (e.g. tas has no peak_demand) as long as the
       windows it does have tile the year.
+  - name: configured_reference_years_have_patterns
+    description: >
+      Every reference year in the model config's
+      temporal.capacity_expansion.reference_year_cycle must appear in
+      reference_year, so each model year has a pattern to draw its windows
+      from. This is a config-to-table check: the table can be valid on its own
+      and still fail it under a particular cycle. Currently enforced by the
+      translator (ispypsa.translator.timeslices), which raises rather than
+      silently producing no windows.
 description: >
   Month-day windows during which each demand-condition timeslice is active,
   one pattern per reference (weather) year.
 
   One row per active window. The translator re-sequences the patterns to the
-  configured reference_year_cycle — each model financial year gets the
-  windows of the reference year assigned to it, the same assignment used for
-  demand and VRE traces — to build time-varying transmission path limits and
-  to restrict custom constraints to the snapshots their RHS values apply to.
+  model config's reference_year_cycle — each model year gets the windows of
+  the reference year assigned to it, the same assignment used for demand and
+  VRE traces — to build time-varying transmission path limits and to restrict
+  custom constraints to the snapshots their RHS values apply to. Windows are
+  month-day ranges applied to each model year's dates directly, so any
+  year_type works: a window is active on a date whenever the date's month-day
+  falls in the window's range.
 
   Source tables:
     - `timeslice_RefYear5000` (PLEXOS data package extract)
@@ -79,16 +89,14 @@ columns:
     required: true
     format: "%m-%d"
     description: >
-      First day of the window (inclusive), e.g. "11-18". Windows belong to
-      the financial year they start in: months July-December fall in the
-      financial year's first calendar year, January-June in its second.
+      First day of the window (inclusive), e.g. "11-18".
   end_month_day:
     type: string
     required: true
     format: "%m-%d"
     description: >
-      Day the window ends (exclusive), interpreted as its first occurrence
-      after the start — "11-18" to "03-20" wraps into the next calendar
-      year, and winter's "04-01" to "10-01" extends past 30 June into the
-      next financial year. "02-29" boundaries (from leap reference years)
-      are clamped to "02-28" when expanded into non-leap model years.
+      Day the window ends (exclusive). An end at or before its start wraps
+      past New Year: "11-18" to "03-20" covers 18 November through 19 March.
+      A "02-29" boundary (from a leap reference year) simply never matches a
+      date in non-leap model years; 28 February stays in whichever window
+      covers "02-28".

--- a/src/ispypsa/validation/schemas/timeslices.yaml
+++ b/src/ispypsa/validation/schemas/timeslices.yaml
@@ -25,9 +25,9 @@ custom_validation:
       temporal.capacity_expansion.reference_year_cycle must appear in
       reference_year, so each model year has a pattern to draw its windows
       from. This is a config-to-table check: the table can be valid on its own
-      and still fail it under a particular cycle. Currently enforced by the
-      translator (ispypsa.translator.timeslices), which raises rather than
-      silently producing no windows.
+      and still fail it under a particular cycle. Skipped when the table is
+      absent or empty — no patterns at all is a valid configuration (see "If
+      absent"); the check only applies when some patterns are supplied.
 description: >
   Month-day windows during which each demand-condition timeslice is active,
   one pattern per reference (weather) year.

--- a/tests/test_translator/test_timeslice_snapshots.py
+++ b/tests/test_translator/test_timeslice_snapshots.py
@@ -1,0 +1,310 @@
+import pandas as pd
+import pytest
+
+from ispypsa.translator.timeslices import (
+    _create_timeslice_snapshot_mapping,
+    _log_referenced_timeslices_without_snapshots,
+)
+
+# sample_model_config: start_year 2026, end_year 2028, year_type fy,
+# reference_year_cycle [2024].
+
+
+def _snapshots(csv_str_to_df, csv_str: str) -> pd.DataFrame:
+    snapshots = csv_str_to_df(csv_str)
+    snapshots["snapshots"] = pd.to_datetime(snapshots["snapshots"])
+    return snapshots
+
+
+def test_pattern_expanded_into_every_model_year(csv_str_to_df, sample_model_config):
+    timeslices = csv_str_to_df("""
+        timeslice_id,     reference_year,  start_month_day,  end_month_day
+        nsw_peak_demand,  2024,            01-13,            01-14
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-01-13 12:00:00
+        2026,                2026-01-14 12:00:00
+        2026,                2027-01-13 12:00:00
+        2028,                2028-01-13 12:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2026-01-13 12:00:00
+        nsw_peak_demand,  2026,                2027-01-13 12:00:00
+        nsw_peak_demand,  2028,                2028-01-13 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(
+        result.sort_values("snapshots").reset_index(drop=True),
+        expected.sort_values("snapshots").reset_index(drop=True),
+    )
+
+
+def test_cycle_assigns_different_patterns_to_different_model_years(
+    csv_str_to_df, sample_model_config
+):
+    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+    timeslices = csv_str_to_df("""
+        timeslice_id,     reference_year,  start_month_day,  end_month_day
+        nsw_peak_demand,  2024,            01-13,            01-14
+        nsw_peak_demand,  2018,            02-01,            02-03
+    """)
+    # FY2026 -> 2024, FY2027 -> 2018, FY2028 -> 2024. Snapshots sit on both
+    # patterns' dates in FY2026 and FY2027; only the assigned pattern tags.
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-01-13 12:00:00
+        2026,                2026-02-02 12:00:00
+        2026,                2027-01-13 12:00:00
+        2026,                2027-02-02 12:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2026-01-13 12:00:00
+        nsw_peak_demand,  2026,                2027-02-02 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(
+        result.sort_values("snapshots").reset_index(drop=True),
+        expected.sort_values("snapshots").reset_index(drop=True),
+    )
+
+
+def test_prior_year_winter_window_covers_first_model_year_july(
+    csv_str_to_df, sample_model_config
+):
+    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+    # The year before the first model year takes the cycle's last reference
+    # year (2018), whose winter window [04-01, 10-01) spills into the first
+    # model year's July-September. 2018's winter ends 10-01 so the October
+    # snapshot is uncovered (2024's FY2026 winter only starts 2026-04-15).
+    timeslices = csv_str_to_df("""
+        timeslice_id,          reference_year,  start_month_day,  end_month_day
+        nsw_winter_reference,  2018,            04-01,            10-01
+        nsw_winter_reference,  2024,            04-15,            10-15
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2025-07-15 12:00:00
+        2026,                2025-10-10 12:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,          investment_periods,  snapshots
+        nsw_winter_reference,  2026,                2025-07-15 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_end_month_day_wraps_past_new_year(csv_str_to_df, sample_model_config):
+    timeslices = csv_str_to_df("""
+        timeslice_id,        reference_year,  start_month_day,  end_month_day
+        nsw_summer_typical,  2024,            11-20,            03-20
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2025-11-20 12:00:00
+        2026,                2026-03-19 12:00:00
+        2026,                2026-03-21 12:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,        investment_periods,  snapshots
+        nsw_summer_typical,  2026,                2025-11-20 12:00:00
+        nsw_summer_typical,  2026,                2026-03-19 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_leap_day_windows_clamped_in_non_leap_years(csv_str_to_df, sample_model_config):
+    # Reference year 2024's pattern carries leap-day boundaries. In leap
+    # FY2028 both windows apply as-is. In non-leap FY2026 the one-day
+    # [02-28, 02-29) window collapses to empty (the 28th is NOT tagged
+    # vic_peak_demand) while the [02-29, 03-02) window clamps its start to
+    # the 28th.
+    timeslices = csv_str_to_df("""
+        timeslice_id,     reference_year,  start_month_day,  end_month_day
+        vic_peak_demand,  2024,            02-28,            02-29
+        nsw_peak_demand,  2024,            02-29,            03-02
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-02-28 12:00:00
+        2028,                2028-02-28 12:00:00
+        2028,                2028-02-29 12:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2026-02-28 12:00:00
+        vic_peak_demand,  2028,                2028-02-28 12:00:00
+        nsw_peak_demand,  2028,                2028-02-29 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(
+        result.sort_values(["snapshots", "timeslice_id"]).reset_index(drop=True),
+        expected.sort_values(["snapshots", "timeslice_id"]).reset_index(drop=True),
+    )
+
+
+def test_raises_on_reference_years_without_patterns(csv_str_to_df, sample_model_config):
+    timeslices = csv_str_to_df("""
+        timeslice_id,     reference_year,  start_month_day,  end_month_day
+        nsw_peak_demand,  2018,            01-13,            01-14
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-01-13 12:00:00
+        """,
+    )
+
+    with pytest.raises(ValueError, match=r"no timeslice window patterns: \[2024\]"):
+        _create_timeslice_snapshot_mapping(timeslices, snapshots, sample_model_config)
+
+
+def test_raises_for_calendar_year_type(csv_str_to_df, sample_model_config):
+    sample_model_config.temporal.year_type = "calendar"
+    timeslices = csv_str_to_df("""
+        timeslice_id,     reference_year,  start_month_day,  end_month_day
+        nsw_peak_demand,  2024,            01-13,            01-14
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-01-13 12:00:00
+        """,
+    )
+
+    with pytest.raises(NotImplementedError, match="only implemented for fy"):
+        _create_timeslice_snapshot_mapping(timeslices, snapshots, sample_model_config)
+
+
+def test_empty_timeslices_table(csv_str_to_df, sample_model_config):
+    timeslices = pd.DataFrame(
+        columns=["timeslice_id", "reference_year", "start_month_day", "end_month_day"]
+    )
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-01-13 12:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = csv_str_to_df("""
+        timeslice_id,  investment_periods,  snapshots
+    """)
+    pd.testing.assert_frame_equal(result, expected, check_dtype=False)
+
+
+def test_logs_referenced_timeslices_without_snapshots(csv_str_to_df, caplog):
+    timeslice_snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2026-01-13 12:00:00
+        """,
+    )
+    link_timeslice_limits = csv_str_to_df("""
+        name,            attribute,  timeslice,        value
+        CQ-NQ_existing,  p_max_pu,   nsw_peak_demand,  0.8
+        CQ-NQ_existing,  p_max_pu,   tas_peak_demand,  0.9
+    """)
+    custom_constraints_rhs = csv_str_to_df("""
+        constraint_name,  investment_period,  timeslice,        rhs,   constraint_type
+        SWQLD1,           2026,               vic_peak_demand,  3000,  <=
+        CQ-NQ_expansion_limit,  ,             ,                 1000,  <=
+    """)
+
+    with caplog.at_level("WARNING"):
+        _log_referenced_timeslices_without_snapshots(
+            timeslice_snapshots, link_timeslice_limits, custom_constraints_rhs
+        )
+
+    assert (
+        "Timeslices referenced by transmission limits or custom constraints "
+        "but with no snapshots in the model (these limits and constraints "
+        "will never apply): ['tas_peak_demand', 'vic_peak_demand']"
+    ) in caplog.text
+
+
+def test_no_log_when_all_referenced_timeslices_have_snapshots(csv_str_to_df, caplog):
+    timeslice_snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2026-01-13 12:00:00
+        """,
+    )
+    link_timeslice_limits = csv_str_to_df("""
+        name,            attribute,  timeslice,        value
+        CQ-NQ_existing,  p_max_pu,   nsw_peak_demand,  0.8
+    """)
+    custom_constraints_rhs = csv_str_to_df("""
+        constraint_name,  investment_period,  timeslice,        rhs,   constraint_type
+        SWQLD1,           2026,               nsw_peak_demand,  3000,  <=
+    """)
+
+    with caplog.at_level("WARNING"):
+        _log_referenced_timeslices_without_snapshots(
+            timeslice_snapshots, link_timeslice_limits, custom_constraints_rhs
+        )
+
+    assert caplog.text == ""

--- a/tests/test_translator/test_timeslice_snapshots.py
+++ b/tests/test_translator/test_timeslice_snapshots.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pytest
 
 from ispypsa.translator.timeslices import (
     _create_timeslice_snapshot_mapping,
@@ -235,7 +234,13 @@ def test_leap_day_windows_in_leap_and_non_leap_years(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_raises_on_reference_years_without_patterns(csv_str_to_df, sample_model_config):
+def test_reference_year_without_patterns_leaves_its_model_years_untagged(
+    csv_str_to_df, sample_model_config
+):
+    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+    # FY2026 -> 2024, FY2027 -> 2018. Only 2018 has a pattern; the schema's
+    # configured_reference_years_have_patterns check (not yet enforced) is
+    # what would catch this, so here FY2026's snapshot is simply untagged.
     timeslices = csv_str_to_df("""
         timeslice_id,     reference_year,  start_month_day,  end_month_day
         nsw_peak_demand,  2018,            01-13,            01-14
@@ -245,11 +250,22 @@ def test_raises_on_reference_years_without_patterns(csv_str_to_df, sample_model_
         """
         investment_periods,  snapshots
         2026,                2026-01-13 12:00:00
+        2026,                2027-01-13 12:00:00
         """,
     )
 
-    with pytest.raises(ValueError, match=r"no timeslice window patterns: \[2024\]"):
-        _create_timeslice_snapshot_mapping(timeslices, snapshots, sample_model_config)
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2027-01-13 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(result, expected)
 
 
 def test_calendar_year_type_switches_pattern_at_new_year(

--- a/tests/test_translator/test_timeslice_snapshots.py
+++ b/tests/test_translator/test_timeslice_snapshots.py
@@ -5,9 +5,6 @@ from ispypsa.translator.timeslices import (
     _log_referenced_timeslices_without_snapshots,
 )
 
-# sample_model_config: start_year 2026, end_year 2028, year_type fy,
-# reference_year_cycle [2024].
-
 
 def _snapshots(csv_str_to_df, csv_str: str) -> pd.DataFrame:
     snapshots = csv_str_to_df(csv_str)
@@ -15,7 +12,7 @@ def _snapshots(csv_str_to_df, csv_str: str) -> pd.DataFrame:
     return snapshots
 
 
-def test_pattern_expanded_into_every_model_year(csv_str_to_df, sample_model_config):
+def test_pattern_expanded_into_every_model_year(csv_str_to_df):
     timeslices = csv_str_to_df("""
         timeslice_id,     reference_year,  start_month_day,  end_month_day
         nsw_peak_demand,  2024,            01-13,            01-14
@@ -32,7 +29,10 @@ def test_pattern_expanded_into_every_model_year(csv_str_to_df, sample_model_conf
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices,
+        snapshots,
+        reference_year_mapping={2026: 2024, 2027: 2024, 2028: 2024},
+        year_type="fy",
     )
 
     expected = _snapshots(
@@ -44,20 +44,14 @@ def test_pattern_expanded_into_every_model_year(csv_str_to_df, sample_model_conf
         nsw_peak_demand,  2028,                2028-01-13 12:00:00
         """,
     )
-    pd.testing.assert_frame_equal(
-        result.sort_values("snapshots").reset_index(drop=True),
-        expected.sort_values("snapshots").reset_index(drop=True),
-    )
+    pd.testing.assert_frame_equal(result, expected)
 
 
-def test_multiple_regions_and_years_each_snapshot_tagged_once_per_region(
-    csv_str_to_df, sample_model_config
-):
-    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+def test_multiple_regions_and_years_each_snapshot_tagged_once_per_region(csv_str_to_df):
     # FY2026 -> 2024, FY2027 -> 2018. Each region and reference year tiles
-    # the year the way the templater emits it: summer split around a peak
-    # window, winter crossing 30 June. Regions are independent, so every
-    # snapshot gets exactly one tag per region; the peak days differ between
+    # the year (covers all intervals) the way the templater emits it: summer
+    # split around a peak window, winter crossing 30 June. Regions are independent,
+    # so every snapshot gets exactly one tag per region; the peak days differ between
     # regions and reference years so the tags visibly diverge.
     timeslices = csv_str_to_df("""
         timeslice_id,          reference_year,  start_month_day,  end_month_day
@@ -93,7 +87,10 @@ def test_multiple_regions_and_years_each_snapshot_tagged_once_per_region(
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices,
+        snapshots,
+        reference_year_mapping={2026: 2024, 2027: 2018},
+        year_type="fy",
     )
 
     expected = _snapshots(
@@ -119,10 +116,7 @@ def test_multiple_regions_and_years_each_snapshot_tagged_once_per_region(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_model_year_boundary_snapshot_uses_year_just_ended(
-    csv_str_to_df, sample_model_config
-):
-    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+def test_model_year_boundary_snapshot_uses_year_just_ended(csv_str_to_df):
     # FY2026 -> 2024, FY2027 -> 2018. The snapshot stamped 2026-07-01 00:00
     # is FY2026's last interval, so it takes 2024's window (peak), not 2018's
     # (summer) even though 1 July belongs to FY2027.
@@ -140,7 +134,10 @@ def test_model_year_boundary_snapshot_uses_year_just_ended(
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices,
+        snapshots,
+        reference_year_mapping={2026: 2024, 2027: 2018},
+        year_type="fy",
     )
 
     expected = _snapshots(
@@ -153,9 +150,7 @@ def test_model_year_boundary_snapshot_uses_year_just_ended(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_boundary_snapshots_belong_to_the_window_ending_there(
-    csv_str_to_df, sample_model_config
-):
+def test_boundary_snapshots_belong_to_the_window_ending_there(csv_str_to_df):
     # Snapshots are stamped with their interval's end time, so a snapshot
     # stamped exactly on the boundary between two adjacent windows is the
     # earlier window's final interval. Summer is split around the peak day,
@@ -177,7 +172,7 @@ def test_boundary_snapshots_belong_to_the_window_ending_there(
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices, snapshots, reference_year_mapping={2026: 2024}, year_type="fy"
     )
 
     expected = _snapshots(
@@ -189,15 +184,10 @@ def test_boundary_snapshots_belong_to_the_window_ending_there(
         nsw_peak_demand,     2026,                2026-01-14 00:00:00
         """,
     )
-    pd.testing.assert_frame_equal(
-        result.sort_values("snapshots").reset_index(drop=True),
-        expected.sort_values("snapshots").reset_index(drop=True),
-    )
+    pd.testing.assert_frame_equal(result, expected)
 
 
-def test_leap_day_windows_in_leap_and_non_leap_years(
-    csv_str_to_df, sample_model_config
-):
+def test_leap_day_windows_in_leap_and_non_leap_years(csv_str_to_df):
     # Reference year 2024's pattern carries leap-day boundaries. Windows are
     # month-day ranges, so 28 February is always in [02-28, 02-29), and
     # 29 February only exists to be tagged in leap FY2028.
@@ -218,7 +208,10 @@ def test_leap_day_windows_in_leap_and_non_leap_years(
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices,
+        snapshots,
+        reference_year_mapping={2026: 2024, 2027: 2024, 2028: 2024},
+        year_type="fy",
     )
 
     expected = _snapshots(
@@ -234,10 +227,7 @@ def test_leap_day_windows_in_leap_and_non_leap_years(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_reference_year_without_patterns_leaves_its_model_years_untagged(
-    csv_str_to_df, sample_model_config
-):
-    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+def test_reference_year_without_patterns_leaves_its_model_years_untagged(csv_str_to_df):
     # FY2026 -> 2024, FY2027 -> 2018. Only 2018 has a pattern; the schema's
     # configured_reference_years_have_patterns check (not yet enforced) is
     # what would catch this, so here FY2026's snapshot is simply untagged.
@@ -255,7 +245,10 @@ def test_reference_year_without_patterns_leaves_its_model_years_untagged(
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices,
+        snapshots,
+        reference_year_mapping={2026: 2024, 2027: 2018},
+        year_type="fy",
     )
 
     expected = _snapshots(
@@ -268,11 +261,7 @@ def test_reference_year_without_patterns_leaves_its_model_years_untagged(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_calendar_year_type_switches_pattern_at_new_year(
-    csv_str_to_df, sample_model_config
-):
-    sample_model_config.temporal.year_type = "calendar"
-    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+def test_calendar_year_type_switches_pattern_at_new_year(csv_str_to_df):
     # Calendar 2026 -> 2024, 2027 -> 2018. Summer wraps past New Year in both
     # patterns; the December snapshot takes 2024's summer and the January one
     # 2018's, so 2018's 01-07 peak day applies but 2024's 12-14 one does not
@@ -297,7 +286,10 @@ def test_calendar_year_type_switches_pattern_at_new_year(
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices,
+        snapshots,
+        reference_year_mapping={2026: 2024, 2027: 2018},
+        year_type="calendar",
     )
 
     expected = _snapshots(
@@ -312,7 +304,7 @@ def test_calendar_year_type_switches_pattern_at_new_year(
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_empty_timeslices_table(csv_str_to_df, sample_model_config):
+def test_empty_timeslices_table(csv_str_to_df):
     timeslices = pd.DataFrame(
         columns=["timeslice_id", "reference_year", "start_month_day", "end_month_day"]
     )
@@ -325,7 +317,7 @@ def test_empty_timeslices_table(csv_str_to_df, sample_model_config):
     )
 
     result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
+        timeslices, snapshots, reference_year_mapping={2026: 2024}, year_type="fy"
     )
 
     expected = csv_str_to_df("""

--- a/tests/test_translator/test_timeslice_snapshots.py
+++ b/tests/test_translator/test_timeslice_snapshots.py
@@ -51,65 +51,45 @@ def test_pattern_expanded_into_every_model_year(csv_str_to_df, sample_model_conf
     )
 
 
-def test_cycle_assigns_different_patterns_to_different_model_years(
+def test_multiple_regions_and_years_each_snapshot_tagged_once_per_region(
     csv_str_to_df, sample_model_config
 ):
     sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
-    timeslices = csv_str_to_df("""
-        timeslice_id,     reference_year,  start_month_day,  end_month_day
-        nsw_peak_demand,  2024,            01-13,            01-14
-        nsw_peak_demand,  2018,            02-01,            02-03
-    """)
-    # FY2026 -> 2024, FY2027 -> 2018, FY2028 -> 2024. Snapshots sit on both
-    # patterns' dates in FY2026 and FY2027; only the assigned pattern tags.
-    snapshots = _snapshots(
-        csv_str_to_df,
-        """
-        investment_periods,  snapshots
-        2026,                2026-01-13 12:00:00
-        2026,                2026-02-02 12:00:00
-        2026,                2027-01-13 12:00:00
-        2026,                2027-02-02 12:00:00
-        """,
-    )
-
-    result = _create_timeslice_snapshot_mapping(
-        timeslices, snapshots, sample_model_config
-    )
-
-    expected = _snapshots(
-        csv_str_to_df,
-        """
-        timeslice_id,     investment_periods,  snapshots
-        nsw_peak_demand,  2026,                2026-01-13 12:00:00
-        nsw_peak_demand,  2026,                2027-02-02 12:00:00
-        """,
-    )
-    pd.testing.assert_frame_equal(
-        result.sort_values("snapshots").reset_index(drop=True),
-        expected.sort_values("snapshots").reset_index(drop=True),
-    )
-
-
-def test_prior_year_winter_window_covers_first_model_year_july(
-    csv_str_to_df, sample_model_config
-):
-    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
-    # The year before the first model year takes the cycle's last reference
-    # year (2018), whose winter window [04-01, 10-01) spills into the first
-    # model year's July-September. 2018's winter ends 10-01 so the October
-    # snapshot is uncovered (2024's FY2026 winter only starts 2026-04-15).
+    # FY2026 -> 2024, FY2027 -> 2018. Each region and reference year tiles
+    # the year the way the templater emits it: summer split around a peak
+    # window, winter crossing 30 June. Regions are independent, so every
+    # snapshot gets exactly one tag per region; the peak days differ between
+    # regions and reference years so the tags visibly diverge.
     timeslices = csv_str_to_df("""
         timeslice_id,          reference_year,  start_month_day,  end_month_day
-        nsw_winter_reference,  2018,            04-01,            10-01
-        nsw_winter_reference,  2024,            04-15,            10-15
+        nsw_summer_typical,    2024,            11-01,            12-14
+        nsw_peak_demand,       2024,            12-14,            12-15
+        nsw_summer_typical,    2024,            12-15,            04-01
+        nsw_winter_reference,  2024,            04-01,            11-01
+        nsw_summer_typical,    2018,            11-01,            01-07
+        nsw_peak_demand,       2018,            01-07,            01-08
+        nsw_summer_typical,    2018,            01-08,            04-01
+        nsw_winter_reference,  2018,            04-01,            11-01
+        vic_summer_typical,    2024,            11-01,            01-20
+        vic_peak_demand,       2024,            01-20,            01-21
+        vic_summer_typical,    2024,            01-21,            04-01
+        vic_winter_reference,  2024,            04-01,            11-01
+        vic_summer_typical,    2018,            11-01,            02-01
+        vic_peak_demand,       2018,            02-01,            02-03
+        vic_summer_typical,    2018,            02-03,            04-01
+        vic_winter_reference,  2018,            04-01,            11-01
     """)
     snapshots = _snapshots(
         csv_str_to_df,
         """
         investment_periods,  snapshots
         2026,                2025-07-15 12:00:00
-        2026,                2025-10-10 12:00:00
+        2026,                2025-12-14 12:00:00
+        2026,                2026-01-01 12:00:00
+        2026,                2026-01-20 12:00:00
+        2026,                2026-05-15 12:00:00
+        2026,                2027-01-07 12:00:00
+        2026,                2027-02-02 12:00:00
         """,
     )
 
@@ -122,23 +102,78 @@ def test_prior_year_winter_window_covers_first_model_year_july(
         """
         timeslice_id,          investment_periods,  snapshots
         nsw_winter_reference,  2026,                2025-07-15 12:00:00
+        vic_winter_reference,  2026,                2025-07-15 12:00:00
+        nsw_peak_demand,       2026,                2025-12-14 12:00:00
+        vic_summer_typical,    2026,                2025-12-14 12:00:00
+        nsw_summer_typical,    2026,                2026-01-01 12:00:00
+        vic_summer_typical,    2026,                2026-01-01 12:00:00
+        nsw_summer_typical,    2026,                2026-01-20 12:00:00
+        vic_peak_demand,       2026,                2026-01-20 12:00:00
+        nsw_winter_reference,  2026,                2026-05-15 12:00:00
+        vic_winter_reference,  2026,                2026-05-15 12:00:00
+        nsw_peak_demand,       2026,                2027-01-07 12:00:00
+        vic_summer_typical,    2026,                2027-01-07 12:00:00
+        nsw_summer_typical,    2026,                2027-02-02 12:00:00
+        vic_peak_demand,       2026,                2027-02-02 12:00:00
         """,
     )
-    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+    pd.testing.assert_frame_equal(result, expected)
 
 
-def test_end_month_day_wraps_past_new_year(csv_str_to_df, sample_model_config):
+def test_model_year_boundary_snapshot_uses_year_just_ended(
+    csv_str_to_df, sample_model_config
+):
+    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+    # FY2026 -> 2024, FY2027 -> 2018. The snapshot stamped 2026-07-01 00:00
+    # is FY2026's last interval, so it takes 2024's window (peak), not 2018's
+    # (summer) even though 1 July belongs to FY2027.
     timeslices = csv_str_to_df("""
         timeslice_id,        reference_year,  start_month_day,  end_month_day
-        nsw_summer_typical,  2024,            11-20,            03-20
+        nsw_peak_demand,     2024,            06-30,            07-01
+        nsw_summer_typical,  2018,            06-30,            07-01
     """)
     snapshots = _snapshots(
         csv_str_to_df,
         """
         investment_periods,  snapshots
-        2026,                2025-11-20 12:00:00
-        2026,                2026-03-19 12:00:00
-        2026,                2026-03-21 12:00:00
+        2026,                2026-07-01 00:00:00
+        """,
+    )
+
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,     investment_periods,  snapshots
+        nsw_peak_demand,  2026,                2026-07-01 00:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_boundary_snapshots_belong_to_the_window_ending_there(
+    csv_str_to_df, sample_model_config
+):
+    # Snapshots are stamped with their interval's end time, so a snapshot
+    # stamped exactly on the boundary between two adjacent windows is the
+    # earlier window's final interval. Summer is split around the peak day,
+    # as the templater emits it.
+    timeslices = csv_str_to_df("""
+        timeslice_id,        reference_year,  start_month_day,  end_month_day
+        nsw_summer_typical,  2024,            11-01,            01-13
+        nsw_peak_demand,     2024,            01-13,            01-14
+        nsw_summer_typical,  2024,            01-14,            04-01
+    """)
+    snapshots = _snapshots(
+        csv_str_to_df,
+        """
+        investment_periods,  snapshots
+        2026,                2026-01-13 00:00:00
+        2026,                2026-01-13 12:00:00
+        2026,                2026-01-14 00:00:00
         """,
     )
 
@@ -150,19 +185,23 @@ def test_end_month_day_wraps_past_new_year(csv_str_to_df, sample_model_config):
         csv_str_to_df,
         """
         timeslice_id,        investment_periods,  snapshots
-        nsw_summer_typical,  2026,                2025-11-20 12:00:00
-        nsw_summer_typical,  2026,                2026-03-19 12:00:00
+        nsw_summer_typical,  2026,                2026-01-13 00:00:00
+        nsw_peak_demand,     2026,                2026-01-13 12:00:00
+        nsw_peak_demand,     2026,                2026-01-14 00:00:00
         """,
     )
-    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+    pd.testing.assert_frame_equal(
+        result.sort_values("snapshots").reset_index(drop=True),
+        expected.sort_values("snapshots").reset_index(drop=True),
+    )
 
 
-def test_leap_day_windows_clamped_in_non_leap_years(csv_str_to_df, sample_model_config):
-    # Reference year 2024's pattern carries leap-day boundaries. In leap
-    # FY2028 both windows apply as-is. In non-leap FY2026 the one-day
-    # [02-28, 02-29) window collapses to empty (the 28th is NOT tagged
-    # vic_peak_demand) while the [02-29, 03-02) window clamps its start to
-    # the 28th.
+def test_leap_day_windows_in_leap_and_non_leap_years(
+    csv_str_to_df, sample_model_config
+):
+    # Reference year 2024's pattern carries leap-day boundaries. Windows are
+    # month-day ranges, so 28 February is always in [02-28, 02-29), and
+    # 29 February only exists to be tagged in leap FY2028.
     timeslices = csv_str_to_df("""
         timeslice_id,     reference_year,  start_month_day,  end_month_day
         vic_peak_demand,  2024,            02-28,            02-29
@@ -173,6 +212,7 @@ def test_leap_day_windows_clamped_in_non_leap_years(csv_str_to_df, sample_model_
         """
         investment_periods,  snapshots
         2026,                2026-02-28 12:00:00
+        2026,                2026-03-01 12:00:00
         2028,                2028-02-28 12:00:00
         2028,                2028-02-29 12:00:00
         """,
@@ -186,15 +226,13 @@ def test_leap_day_windows_clamped_in_non_leap_years(csv_str_to_df, sample_model_
         csv_str_to_df,
         """
         timeslice_id,     investment_periods,  snapshots
-        nsw_peak_demand,  2026,                2026-02-28 12:00:00
+        vic_peak_demand,  2026,                2026-02-28 12:00:00
+        nsw_peak_demand,  2026,                2026-03-01 12:00:00
         vic_peak_demand,  2028,                2028-02-28 12:00:00
         nsw_peak_demand,  2028,                2028-02-29 12:00:00
         """,
     )
-    pd.testing.assert_frame_equal(
-        result.sort_values(["snapshots", "timeslice_id"]).reset_index(drop=True),
-        expected.sort_values(["snapshots", "timeslice_id"]).reset_index(drop=True),
-    )
+    pd.testing.assert_frame_equal(result, expected)
 
 
 def test_raises_on_reference_years_without_patterns(csv_str_to_df, sample_model_config):
@@ -214,22 +252,48 @@ def test_raises_on_reference_years_without_patterns(csv_str_to_df, sample_model_
         _create_timeslice_snapshot_mapping(timeslices, snapshots, sample_model_config)
 
 
-def test_raises_for_calendar_year_type(csv_str_to_df, sample_model_config):
+def test_calendar_year_type_switches_pattern_at_new_year(
+    csv_str_to_df, sample_model_config
+):
     sample_model_config.temporal.year_type = "calendar"
+    sample_model_config.temporal.capacity_expansion.reference_year_cycle = [2024, 2018]
+    # Calendar 2026 -> 2024, 2027 -> 2018. Summer wraps past New Year in both
+    # patterns; the December snapshot takes 2024's summer and the January one
+    # 2018's, so 2018's 01-07 peak day applies but 2024's 12-14 one does not
+    # to the (2018-governed) 2027 December.
     timeslices = csv_str_to_df("""
-        timeslice_id,     reference_year,  start_month_day,  end_month_day
-        nsw_peak_demand,  2024,            01-13,            01-14
+        timeslice_id,        reference_year,  start_month_day,  end_month_day
+        nsw_summer_typical,  2024,            11-01,            12-14
+        nsw_peak_demand,     2024,            12-14,            12-15
+        nsw_summer_typical,  2024,            12-15,            04-01
+        nsw_summer_typical,  2018,            11-01,            01-07
+        nsw_peak_demand,     2018,            01-07,            01-08
+        nsw_summer_typical,  2018,            01-08,            04-01
     """)
     snapshots = _snapshots(
         csv_str_to_df,
         """
         investment_periods,  snapshots
-        2026,                2026-01-13 12:00:00
+        2026,                2026-12-14 12:00:00
+        2026,                2027-01-07 12:00:00
+        2026,                2027-12-14 12:00:00
         """,
     )
 
-    with pytest.raises(NotImplementedError, match="only implemented for fy"):
-        _create_timeslice_snapshot_mapping(timeslices, snapshots, sample_model_config)
+    result = _create_timeslice_snapshot_mapping(
+        timeslices, snapshots, sample_model_config
+    )
+
+    expected = _snapshots(
+        csv_str_to_df,
+        """
+        timeslice_id,        investment_periods,  snapshots
+        nsw_peak_demand,     2026,                2026-12-14 12:00:00
+        nsw_peak_demand,     2026,                2027-01-07 12:00:00
+        nsw_summer_typical,  2026,                2027-12-14 12:00:00
+        """,
+    )
+    pd.testing.assert_frame_equal(result, expected)
 
 
 def test_empty_timeslices_table(csv_str_to_df, sample_model_config):


### PR DESCRIPTION
Adds the translator-side timeslice module. It maps each templated timeslice window pattern onto the model's snapshots, producing a `timeslice_snapshots` table (`timeslice_id, investment_periods, snapshots`) that later functionality will use to apply per-timeslice link limits and to scope the temporal custom constraints.

```
src/ispypsa/translator/
└── timeslices.py                        → match snapshots to timeslice windows on month-day
src/ispypsa/validation/schemas/
└── timeslices.yaml                      → month-day window semantics; config-to-table validation entry
tests/test_translator/
└── test_timeslice_snapshots.py          → one realistic multi-region/multi-year case plus one test per edge rule
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
