### PR TITLE
Template new entrant regional granularity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,7 +190,7 @@ notes/
 .vscode/
 .DS_Store
 # ignore claude stuff
-.claude/settings.local.json
+.claude/
 CLAUDE.local.md
 
 # ignore all pypsa output files

--- a/src/ispypsa/templater/create_template.py
+++ b/src/ispypsa/templater/create_template.py
@@ -21,7 +21,10 @@ from ispypsa.templater.flow_paths import (
     _template_sub_regional_flow_path_costs,
     _template_sub_regional_flow_paths,
 )
-from ispypsa.templater.geography import _template_network_geography
+from ispypsa.templater.geography import (
+    _build_geo_region_lookup,
+    _template_network_geography,
+)
 from ispypsa.templater.network_expansion import (
     _extract_flow_path_costs_from_iasr,
     _extract_flow_path_options_from_iasr,
@@ -78,7 +81,7 @@ _BASE_TEMPLATE_OUTPUTS = [
 ]
 
 # Outputs from the new-format templater branch. Granularity-invariant: the
-# same five tables are emitted for sub_regions, nem_regions, and single_region
+# same tables are emitted for sub_regions, nem_regions, and single_region
 # (only their contents differ).
 # FEATURE_FLAG_CLEANUP[use_new_table_format]: rename to _TEMPLATE_OUTPUTS and
 # delete _BASE_TEMPLATE_OUTPUTS above.
@@ -88,6 +91,9 @@ _NEW_FORMAT_TEMPLATE_OUTPUTS = [
     "network_transmission_path_limits",
     "network_expansion_options",
     "network_transmission_path_expansion_costs",
+    "costs_connection",
+    "generators_new_entrant",
+    "storage_new_entrant",
 ]
 
 # Custom constraints are templated only at sub_regions granularity (see the gate
@@ -190,9 +196,7 @@ def create_ispypsa_inputs_template(
                 iasr_tables["renewable_energy_zones"],
                 regional_granularity,
             )
-        region_lookup = dict(
-            zip(sub_regional_geography["geo_id"], sub_regional_geography["region_id"])
-        )
+        region_lookup = _build_geo_region_lookup(sub_regional_geography)
         flow_path_options = _filter_flow_path_augmentations_to_granularity(
             _extract_flow_path_options_from_iasr(iasr_tables),
             regional_granularity,
@@ -232,15 +236,18 @@ def create_ispypsa_inputs_template(
             "connection_capacity_non_vre"
         ].copy()
 
-        # Not yet a templater output - fed into connection cost templating below.
-        generators_new_entrant = _template_generators_new_entrant(iasr_tables)
-        storage_new_entrant = _template_storage_new_entrant(iasr_tables)
+        template["generators_new_entrant"] = _template_generators_new_entrant(
+            iasr_tables, regional_granularity, sub_regional_geography
+        )
+        template["storage_new_entrant"] = _template_storage_new_entrant(
+            iasr_tables, regional_granularity, sub_regional_geography
+        )
         template["costs_connection"] = _template_connection_costs(
             iasr_tables,
             scenario,
             regional_granularity,
-            generators_new_entrant,
-            storage_new_entrant,
+            template["generators_new_entrant"],
+            template["storage_new_entrant"],
             sub_regional_geography,
         )
         # Custom constraints from PLEXOS are sub-regional export-group limits:

--- a/src/ispypsa/templater/geography.py
+++ b/src/ispypsa/templater/geography.py
@@ -274,3 +274,29 @@ def _rez_rows_for_single_region(
 def _extract_subregion_id(series: pd.Series) -> pd.Series:
     """Extract subregion ID from 'Name (ID)' format, e.g. 'Northern Queensland (NQ)' -> 'NQ'."""
     return series.str.extract(r"\(([A-Z]+)\)", expand=False)
+
+
+def _build_geo_region_lookup(sub_regional_geography: pd.DataFrame) -> dict[str, str]:
+    """Maps every geo (sub-region, REZ, or NEM region) to its NEM region id.
+
+    ``sub_regional_geography`` already lists both sub-regions and REZs against their
+    ``region_id``. NEM regions are added as identities so that geos which are
+    already regions — after granularity aggregation, or on new parallel corridors —
+    resolve to themselves.
+
+    I/O Example:
+        sub_regional_geography:
+            geo_id  geo_type   region_id
+            NQ      subregion  QLD
+            CNSW    subregion  NSW
+            Q1      rez        QLD
+
+        returns:
+            {"NQ": "QLD", "CNSW": "NSW", "Q1": "QLD", "QLD": "QLD", "NSW": "NSW"}
+    """
+    lookup = dict(
+        zip(sub_regional_geography["geo_id"], sub_regional_geography["region_id"])
+    )
+    for region in set(sub_regional_geography["region_id"]):
+        lookup[region] = region
+    return lookup

--- a/src/ispypsa/templater/new_entrants.py
+++ b/src/ispypsa/templater/new_entrants.py
@@ -20,6 +20,12 @@ There are two independent public orchestrators, one per output table. Each one:
     6. Merges in the two locational cost factors: lcf_build (per geo_id + technology)
        and lcf_om (per geo_id alone) — see _merge_lcf_build and _merge_lcf_om.
     7. Selects the table's schema columns.
+    8. Collapses geo_id to the model's regional_granularity — see _collapse_geo_id_to_granularity.
+       REZ-located (VRE) rows are left untouched at every granularity.
+       Sub-region-located (thermal/storage) rows with the same technology are merged
+       into one row per collapsed geo_id, taking the mean of every numeric property.
+       Known duplicate build option (see _KNOWN_DUPLICATE_SUBREGION_OPTIONS) dropped
+       to avoid double-weighting the CNSW subregion values.
 
 Note: lcf_build is taken directly from IASR's precomputed technology_specific_lcfs table,
 rather than recomputed from the more granular cost-component IASR tables at this
@@ -30,6 +36,7 @@ import logging
 
 import pandas as pd
 
+from ispypsa.templater.geography import _build_geo_region_lookup
 from ispypsa.templater.helpers import (
     _fuzzy_map_to_allowed_values,
     _is_battery_row,
@@ -40,6 +47,7 @@ from ispypsa.templater.helpers import (
 from ispypsa.templater.mappings import (
     _COMMON_NEW_ENTRANT_PROPERTY_MAP,
     _GENERATORS_NEW_ENTRANT_PROPERTY_MAP,
+    _SINGLE_REGION_ID,
     _STORAGE_BATTERY_PROPERTY_MAP,
     _STORAGE_PHES_PROPERTY_MAP,
 )
@@ -50,7 +58,6 @@ _GENERATOR_IDENTITY_COLUMNS = [
     "resource_type",
     "geo_id",
     "fuel_type",
-    "fuel_price_mapping",
 ]
 
 # Explicit output order (schema order)
@@ -88,12 +95,27 @@ _STORAGE_PROPERTY_COLUMNS = [
     "degradation_annual",
 ]
 
+# Columns that define a distinct sub-region-located technology option for granularity
+# collapse (see _collapse_geo_id_to_granularity).
+_GENERATOR_GEO_ID_GROUP_KEYS = ["technology", "resource_type", "fuel_type"]
+_STORAGE_GEO_ID_GROUP_KEYS = ["technology", "fuel_type"]
+
+# A second named build option for the same technology/sub-region - dropped before
+# cross-sub-region aggregation so it doesn't double-weight CNSW in the average;
+# left as-is (so still visible) at sub_regions granularity.
+# See Open-ISP/ISPyPSA#131.
+_KNOWN_DUPLICATE_SUBREGION_OPTIONS = {
+    "WOO OCGT Small",
+    "WOO OCGT Large",
+    "WOO CCGT",
+    "WOO CCGT with CCS",
+}
+
 # Source (IASR new_entrants_summary) column names → schema output column names.
 _SUMMARY_COLUMN_RENAMES = {
     "IASR ID / DLT names": "name",
     "Technology Type": "technology",
     "Fuel type": "fuel_type",
-    "Fuel cost mapping": "fuel_price_mapping",
 }
 
 # TODO(revisit): Distributed Resources Solar currently gets no resource_type; add a
@@ -116,16 +138,13 @@ _RESOURCE_CODE_PATTERN = "_({})_".format(
 )
 
 # BOTN - Cethana is the one named, site-specific PHES project among the generic
-# technologies. This mapping assists this special case handling through templating.
+# technologies. These two mappings assist this special case handling through templating.
 _BOTN_CETHANA_DETAILS = {
     "name": "BOTN - Cethana",
     "full_name": "BOTN - Cethana - 20h",  # pumped_hydro_new_entrant_properties keys it this way
     "technology": "Pumped Hydro (24hrs storage)",  # its generic tech in new_entrants_summary
 }
 
-# The pumped-hydro table is the lone property table that keys BOTN by its full_name;
-# every other property table uses the shorter (no ' - 20h') name. Renaming the
-# key lets the PHES merge run as a plain technology-keyed merge (see _normalise_phes_botn_key).
 _PHES_PROPERTY_KEY_RENAMES = {
     _BOTN_CETHANA_DETAILS["full_name"]: _BOTN_CETHANA_DETAILS["name"]
 }
@@ -144,6 +163,8 @@ _LCF_COLUMNS_IN_PERCENT = ["BOTN - Cethana"]
 
 def _template_generators_new_entrant(
     iasr_tables: dict[str, pd.DataFrame],
+    regional_granularity: str,
+    sub_regional_geography: pd.DataFrame,
 ) -> pd.DataFrame:
     """Templates the new entrant generators table from the IASR summary and properties.
 
@@ -151,14 +172,18 @@ def _template_generators_new_entrant(
     names, derives geo_id (REZ ID or sub-region) and resource_type (from the VRE
     resource code in the IASR ID), merges in the per-technology property columns
     (see ``_GENERATORS_NEW_ENTRANT_PROPERTY_MAP``) and the two locational cost factors
-    (``lcf_build`` per geo_id+technology, ``lcf_om`` per geo_id), and returns the
-    identity + property columns.
+    (``lcf_build`` per geo_id+technology, ``lcf_om`` per geo_id), collapses geo_id to
+    ``regional_granularity`` (see ``_collapse_geo_id_to_granularity``), and returns
+    the identity + property columns.
 
     Args:
         iasr_tables: IASR tables; uses ``new_entrants_summary`` plus the property
             tables named in ``_GENERATORS_NEW_ENTRANT_PROPERTY_MAP``.
+        regional_granularity: "sub_regions", "nem_regions", or "single_region".
+        sub_regional_geography: network_geography templated at "sub_regions"
+            granularity; columns used: 'geo_id', 'geo_type', 'region_id'.
 
-    I/O Example (identity columns abbreviated to name/technology):
+    I/O Example (identity columns abbreviated to name/technology; regional_granularity="sub_regions"):
         new_entrants_summary:
             IASR ID / DLT names  Technology Type  ...
             N3_WH_rez            Wind             ...
@@ -184,11 +209,20 @@ def _template_generators_new_entrant(
     _assert_build_cost_zone_matches_geo_id(gens)
     gens = _merge_lcf_build(gens, iasr_tables["technology_specific_lcfs"])
     gens = _merge_lcf_om(gens, iasr_tables["locational_cost_factors"])
-    return gens[_GENERATOR_IDENTITY_COLUMNS + _GENERATOR_PROPERTY_COLUMNS]
+    gens = gens[_GENERATOR_IDENTITY_COLUMNS + _GENERATOR_PROPERTY_COLUMNS]
+    return _collapse_geo_id_to_granularity(
+        gens,
+        regional_granularity,
+        sub_regional_geography,
+        _GENERATOR_GEO_ID_GROUP_KEYS,
+        _GENERATOR_PROPERTY_COLUMNS,
+    )
 
 
 def _template_storage_new_entrant(
     iasr_tables: dict[str, pd.DataFrame],
+    regional_granularity: str,
+    sub_regional_geography: pd.DataFrame,
 ) -> pd.DataFrame:
     """Templates the new entrant storage table from the IASR summary and properties.
 
@@ -198,13 +232,17 @@ def _template_storage_new_entrant(
     separately and recombined; the shared properties (see
     ``_COMMON_NEW_ENTRANT_PROPERTY_MAP``) and the two locational cost factors
     (``lcf_build`` per geo_id+technology, ``lcf_om`` per geo_id) are then merged onto the
-    combined set.
+    combined set, and geo_id is collapsed to ``regional_granularity`` (see
+    ``_collapse_geo_id_to_granularity``).
 
     Args:
         iasr_tables: IASR tables; uses ``new_entrants_summary`` plus the property tables
             named in the storage property maps and ``_COMMON_NEW_ENTRANT_PROPERTY_MAP``.
+        regional_granularity: "sub_regions", "nem_regions", or "single_region".
+        sub_regional_geography: network_geography templated at "sub_regions"
+            granularity; columns used: 'geo_id', 'geo_type', 'region_id'.
 
-    I/O Example (identity columns abbreviated to name/technology):
+    I/O Example (identity columns abbreviated to name/technology; regional_granularity="sub_regions"):
         new_entrants_summary:
             IASR ID / DLT names  Technology Type                ...
             NQ Battery - 2h      Battery Storage (2hrs storage)  ...
@@ -234,7 +272,14 @@ def _template_storage_new_entrant(
     _assert_build_cost_zone_matches_geo_id(storage)
     storage = _merge_lcf_build(storage, iasr_tables["technology_specific_lcfs"])
     storage = _merge_lcf_om(storage, iasr_tables["locational_cost_factors"])
-    return storage[_STORAGE_IDENTITY_COLUMNS + _STORAGE_PROPERTY_COLUMNS]
+    storage = storage[_STORAGE_IDENTITY_COLUMNS + _STORAGE_PROPERTY_COLUMNS]
+    return _collapse_geo_id_to_granularity(
+        storage,
+        regional_granularity,
+        sub_regional_geography,
+        _STORAGE_GEO_ID_GROUP_KEYS,
+        _STORAGE_PROPERTY_COLUMNS,
+    )
 
 
 # --- shared helpers ---
@@ -402,6 +447,153 @@ def _set_geo_id(new_entrants: pd.DataFrame) -> pd.DataFrame:
     """
     new_entrants["geo_id"] = new_entrants.apply(_pick_location, axis=1)
     return new_entrants
+
+
+# --- regional granularity collapse ---
+
+
+def _collapse_geo_id_to_granularity(
+    new_entrants: pd.DataFrame,
+    regional_granularity: str,
+    sub_regional_geography: pd.DataFrame,
+    group_key_columns: list[str],
+    value_columns: list[str],
+) -> pd.DataFrame:
+    """Aggregates subregional options sharing ``group_key_columns`` to ``regional_granularity``.
+
+    No-op at "sub_regions" (already the finest granularity). Otherwise:
+        1. Splits ``new_entrants`` into REZ rows (left untouched) and subregion rows.
+        2. Subregion rows get grouped by ``group_key_columns`` + the re-keyed geo_id and
+            averaged over ``value_columns``.
+        3. Aggregated rows' 'name' set to "{geo_id} {technology}" (except BOTN - see
+            ``_name_collapsed_rows``).
+        4. Returns concatted REZ rows and aggregated rows.
+
+    Args:
+        new_entrants: identity + property columns, one row per subregion/REZ
+            technology option.
+        regional_granularity: "sub_regions", "nem_regions", or "single_region".
+        sub_regional_geography: network_geography templated at "sub_regions"
+            granularity; columns used: 'geo_id', 'geo_type', 'region_id'.
+        group_key_columns: identity columns (besides geo_id and name) that define a
+            distinct technology option.
+        value_columns: every property column to average through the merge.
+
+    I/O Example (regional_granularity="nem_regions"; two sub-regions in one region):
+        new_entrants:
+            name             technology       geo_id  lcf_build
+            CNSW OCGT Small  OCGT (small GT)  CNSW    104.0
+            SNW OCGT Small   OCGT (small GT)  SNW     100.0
+
+        sub_regional_geography:
+            geo_id  geo_type   region_id
+            CNSW    subregion  NSW
+            SNW     subregion  NSW
+
+        returns:
+            name                 technology       geo_id  lcf_build
+            NSW OCGT (small GT)  OCGT (small GT)  NSW     102.0  # mean(104, 100)
+    """
+    if regional_granularity == "sub_regions":
+        return new_entrants
+
+    is_subregion = _is_subregion_geo_id(new_entrants["geo_id"], sub_regional_geography)
+    unchanged = new_entrants[~is_subregion]
+    to_collapse = new_entrants[is_subregion]
+    if to_collapse.empty:
+        return new_entrants
+
+    to_collapse = to_collapse[
+        ~to_collapse["name"].isin(_KNOWN_DUPLICATE_SUBREGION_OPTIONS)
+    ]
+    _assert_no_unexpected_duplicate_options(to_collapse, group_key_columns)
+
+    to_collapse["geo_id"] = _map_geo_id_to_granularity(
+        to_collapse["geo_id"], regional_granularity, sub_regional_geography
+    )
+    collapsed = _aggregate_by_geo_id(to_collapse, group_key_columns, value_columns)
+    collapsed = _name_collapsed_rows(collapsed)
+
+    return pd.concat([unchanged, collapsed], ignore_index=True)[new_entrants.columns]
+
+
+# NOTE: maybe move to helpers.py in future?
+def _is_subregion_geo_id(
+    geo_id: pd.Series, sub_regional_geography: pd.DataFrame
+) -> pd.Series:
+    """Boolean mask of ``geo_id`` values that are sub-region-located (not REZ)."""
+    geo_type_by_geo_id = sub_regional_geography.set_index("geo_id")["geo_type"]
+    return geo_id.map(geo_type_by_geo_id) == "subregion"
+
+
+def _assert_no_unexpected_duplicate_options(
+    to_collapse: pd.DataFrame, group_key_columns: list[str]
+) -> None:
+    """Raises if a (``group_key_columns``, geo_id) combination has more than one row.
+
+    A repeat here would silently skew the cross-sub-region average toward whichever
+    sub-region has the extra row — the same failure mode
+    ``_KNOWN_DUPLICATE_SUBREGION_OPTIONS`` guards against for the one known "WOO"
+    case. Any other repeat is unexpected at this stage.
+
+    Raises:
+        ValueError: if any (``group_key_columns``, geo_id) combination has more than
+            one row.
+    """
+    option_counts = to_collapse.groupby(
+        group_key_columns + ["geo_id"], dropna=False
+    ).size()
+    unexpected = option_counts[option_counts > 1]
+    if not unexpected.empty:
+        raise ValueError(
+            "Unexpected duplicate new_entrant technology options: "
+            f"{sorted(unexpected.index)}"
+        )
+
+
+def _aggregate_by_geo_id(
+    new_entrants: pd.DataFrame,
+    group_key_columns: list[str],
+    value_columns: list[str],
+) -> pd.DataFrame:
+    """Groups by ``group_key_columns`` + 'geo_id' and averages ``value_columns``."""
+    # 'dropna=False' set to keep thermal generator rows (w/ NaN 'resource_type')
+    return new_entrants.groupby(
+        group_key_columns + ["geo_id"], dropna=False, as_index=False
+    )[value_columns].mean()
+
+
+def _map_geo_id_to_granularity(
+    geo_id: pd.Series, regional_granularity: str, sub_regional_geography: pd.DataFrame
+) -> pd.Series:
+    """Maps sub-region geo_ids to their region_id ("nem_regions") or "NEM" ("single_region")."""
+    if regional_granularity == "single_region":
+        return pd.Series(_SINGLE_REGION_ID, index=geo_id.index)
+    return geo_id.map(_build_geo_region_lookup(sub_regional_geography))
+
+
+def _name_collapsed_rows(collapsed: pd.DataFrame) -> pd.DataFrame:
+    """Sets 'name' on merged rows to "{geo_id} {technology}".
+
+    The lone documented exception is BOTN - Cethana (see ``_BOTN_CETHANA_DETAILS``):
+    a named, site-specific project rather than a generic technology archetype, which
+    keeps its original 'name'.
+
+    I/O Example:
+        collapsed:
+            technology       geo_id
+            OCGT (small GT)  NSW
+            BOTN - Cethana   TAS
+
+        returns:
+            technology       geo_id  name
+            OCGT (small GT)  NSW     NSW OCGT (small GT)
+            BOTN - Cethana   TAS     BOTN - Cethana - 20h  # original name kept
+    """
+    fresh_name = collapsed["geo_id"] + " " + collapsed["technology"]
+    is_botn = collapsed["technology"] == _BOTN_CETHANA_DETAILS["name"]
+    collapsed["name"] = fresh_name.mask(is_botn, _BOTN_CETHANA_DETAILS["full_name"])
+    return collapsed
 
 
 # --- locational cost factor (LCF) helpers ---

--- a/src/ispypsa/templater/new_entrants.py
+++ b/src/ispypsa/templater/new_entrants.py
@@ -24,8 +24,6 @@ There are two independent public orchestrators, one per output table. Each one:
        REZ-located (VRE) rows are left untouched at every granularity.
        Sub-region-located (thermal/storage) rows with the same technology are merged
        into one row per collapsed geo_id, taking the mean of every numeric property.
-       Known duplicate build option (see _KNOWN_DUPLICATE_SUBREGION_OPTIONS) dropped
-       to avoid double-weighting the CNSW subregion values.
 
 Note: lcf_build is taken directly from IASR's precomputed technology_specific_lcfs table,
 rather than recomputed from the more granular cost-component IASR tables at this
@@ -99,17 +97,6 @@ _STORAGE_PROPERTY_COLUMNS = [
 # collapse (see _collapse_geo_id_to_granularity).
 _GENERATOR_GEO_ID_GROUP_KEYS = ["technology", "resource_type", "fuel_type"]
 _STORAGE_GEO_ID_GROUP_KEYS = ["technology", "fuel_type"]
-
-# A second named build option for the same technology/sub-region - dropped before
-# cross-sub-region aggregation so it doesn't double-weight CNSW in the average;
-# left as-is (so still visible) at sub_regions granularity.
-# See Open-ISP/ISPyPSA#131.
-_KNOWN_DUPLICATE_SUBREGION_OPTIONS = {
-    "WOO OCGT Small",
-    "WOO OCGT Large",
-    "WOO CCGT",
-    "WOO CCGT with CCS",
-}
 
 # Source (IASR new_entrants_summary) column names → schema output column names.
 _SUMMARY_COLUMN_RENAMES = {
@@ -498,15 +485,10 @@ def _collapse_geo_id_to_granularity(
         return new_entrants
 
     is_subregion = _is_subregion_geo_id(new_entrants["geo_id"], sub_regional_geography)
-    unchanged = new_entrants[~is_subregion]
-    to_collapse = new_entrants[is_subregion]
+    unchanged = new_entrants[~is_subregion].copy()
+    to_collapse = new_entrants[is_subregion].copy()
     if to_collapse.empty:
         return new_entrants
-
-    to_collapse = to_collapse[
-        ~to_collapse["name"].isin(_KNOWN_DUPLICATE_SUBREGION_OPTIONS)
-    ]
-    _assert_no_unexpected_duplicate_options(to_collapse, group_key_columns)
 
     to_collapse["geo_id"] = _map_geo_id_to_granularity(
         to_collapse["geo_id"], regional_granularity, sub_regional_geography
@@ -524,31 +506,6 @@ def _is_subregion_geo_id(
     """Boolean mask of ``geo_id`` values that are sub-region-located (not REZ)."""
     geo_type_by_geo_id = sub_regional_geography.set_index("geo_id")["geo_type"]
     return geo_id.map(geo_type_by_geo_id) == "subregion"
-
-
-def _assert_no_unexpected_duplicate_options(
-    to_collapse: pd.DataFrame, group_key_columns: list[str]
-) -> None:
-    """Raises if a (``group_key_columns``, geo_id) combination has more than one row.
-
-    A repeat here would silently skew the cross-sub-region average toward whichever
-    sub-region has the extra row — the same failure mode
-    ``_KNOWN_DUPLICATE_SUBREGION_OPTIONS`` guards against for the one known "WOO"
-    case. Any other repeat is unexpected at this stage.
-
-    Raises:
-        ValueError: if any (``group_key_columns``, geo_id) combination has more than
-            one row.
-    """
-    option_counts = to_collapse.groupby(
-        group_key_columns + ["geo_id"], dropna=False
-    ).size()
-    unexpected = option_counts[option_counts > 1]
-    if not unexpected.empty:
-        raise ValueError(
-            "Unexpected duplicate new_entrant technology options: "
-            f"{sorted(unexpected.index)}"
-        )
 
 
 def _aggregate_by_geo_id(

--- a/src/ispypsa/templater/transmission.py
+++ b/src/ispypsa/templater/transmission.py
@@ -2,6 +2,7 @@ import logging
 
 import pandas as pd
 
+from ispypsa.templater.geography import _build_geo_region_lookup
 from ispypsa.templater.mappings import _CANONICAL_TIMESLICES, _SINGLE_REGION_ID
 
 _HVDC_PATH_IDS = {"NNSW-SQ_Terranora", "WNV-CSA_Murraylink", "TAS-SEV"}
@@ -185,32 +186,6 @@ def _aggregate_to_granularity(
 
 
 # --- Region-prefixed timeslices ---
-
-
-def _build_geo_region_lookup(sub_regional_geography: pd.DataFrame) -> dict[str, str]:
-    """Maps every geo (sub-region, REZ, or NEM region) to its NEM region id.
-
-    ``sub_regional_geography`` already lists both sub-regions and REZs against their
-    ``region_id``. NEM regions are added as identities so that geos which are
-    already regions — after granularity aggregation, or on new parallel corridors —
-    resolve to themselves.
-
-    I/O Example:
-        sub_regional_geography:
-            geo_id  geo_type   region_id
-            NQ      subregion  QLD
-            CNSW    subregion  NSW
-            Q1      rez        QLD
-
-        returns:
-            {"NQ": "QLD", "CNSW": "NSW", "Q1": "QLD", "QLD": "QLD", "NSW": "NSW"}
-    """
-    lookup = dict(
-        zip(sub_regional_geography["geo_id"], sub_regional_geography["region_id"])
-    )
-    for region in set(sub_regional_geography["region_id"]):
-        lookup[region] = region
-    return lookup
 
 
 def _add_region_to_timeslices(

--- a/src/ispypsa/validation/schemas/generators_new_entrant.yaml
+++ b/src/ispypsa/validation/schemas/generators_new_entrant.yaml
@@ -69,16 +69,6 @@ columns:
 
       This column is used to define the `carrier` for the generating unit in the
       PyPSA model, and to map to fuel prices.
-  fuel_price_mapping:
-    type: string
-    required: true
-    allowed_values_from:
-      - costs_fuel_prices: fuel_price_mapping
-    description: >
-      The string that maps to fuel costs for this generator.
-
-      For new entrant generators, fuel prices (e.g. for OCGT) are given at the regional
-      node level such as "QLD new OCGT".
   fom:
     type: float
     required: true

--- a/tests/test_cli/test_create_ispypsa_inputs_new_table_formats.py
+++ b/tests/test_cli/test_create_ispypsa_inputs_new_table_formats.py
@@ -72,6 +72,8 @@ _NEW_FORMAT_OUTPUTS = [
     "network_expansion_options",
     "network_transmission_path_expansion_costs",
     "costs_connection",
+    "generators_new_entrant",
+    "storage_new_entrant",
 ]
 
 # Custom constraints are templated only at sub_regions (coarser granularities
@@ -286,6 +288,28 @@ _EXPECTED_EXPANSION_COST_ROWS_75 = {
     "single_region": 1209,
 }
 
+_EXPECTED_COSTS_CONNECTION_ROWS_75 = {
+    "sub_regions": 14725,
+    "nem_regions": 10385,
+    "single_region": 8649,
+}
+
+# Drift-detection only
+_EXPECTED_GENERATORS_NEW_ENTRANT_ROWS_75 = {
+    "sub_regions": 282,
+    "nem_regions": 218,
+    "single_region": 194,
+}
+_EXPECTED_STORAGE_NEW_ENTRANT_ROWS_75 = {
+    "sub_regions": 235,
+    "nem_regions": 167,
+    "single_region": 135,
+}
+
+# "Non-REZ" placeholder REZ IDs used by generation technologies with no specific
+# REZ location (state-wide VRE/DER). See Open-ISP/ISPyPSA#133
+_NON_REZ_PLACEHOLDER_GEO_IDS = {"N0", "V0"}
+
 
 @pytest.mark.parametrize("granularity", ["sub_regions", "nem_regions", "single_region"])
 def test_create_ispypsa_inputs_new_format(
@@ -315,6 +339,9 @@ def test_create_ispypsa_inputs_new_format(
     limits = pd.read_csv(output_dir / "network_transmission_path_limits.csv")
     options = pd.read_csv(output_dir / "network_expansion_options.csv")
     costs = pd.read_csv(output_dir / "network_transmission_path_expansion_costs.csv")
+    costs_connection = pd.read_csv(output_dir / "costs_connection.csv")
+    gens_new_entrant = pd.read_csv(output_dir / "generators_new_entrant.csv")
+    storage_new_entrant = pd.read_csv(output_dir / "storage_new_entrant.csv")
 
     # network_geography — one row per (sub-)region or REZ; geo_ids are unique.
     assert len(geo) == _GEOS_PER_GRANULARITY_75[granularity] + _NUM_REZS_75
@@ -354,6 +381,31 @@ def test_create_ispypsa_inputs_new_format(
     # is uneven).
     assert set(costs["expansion_id"]) == set(options["expansion_id"])
     assert len(costs) == _EXPECTED_EXPANSION_COST_ROWS_75[granularity]
+
+    # generators_new_entrant / storage_new_entrant — row counts drop at coarser
+    # granularities as sub-region-located technology options merge into one row
+    # per region (REZ-located rows are unaffected). geo_ids are real network_geography
+    # entries, except the pre-existing "Non-REZ" placeholder gap (ISPyPSA#133)
+    assert (
+        len(gens_new_entrant) == _EXPECTED_GENERATORS_NEW_ENTRANT_ROWS_75[granularity]
+    )
+    assert gens_new_entrant["name"].is_unique
+    assert set(gens_new_entrant["geo_id"]) <= (
+        set(geo["geo_id"]) | _NON_REZ_PLACEHOLDER_GEO_IDS
+    )
+
+    assert (
+        len(storage_new_entrant) == _EXPECTED_STORAGE_NEW_ENTRANT_ROWS_75[granularity]
+    )
+    assert storage_new_entrant["name"].is_unique
+    assert set(storage_new_entrant["geo_id"]) <= set(geo["geo_id"])
+
+    # costs_connection - every new entrant technology + geo_id + year has a row
+    # geo_id's are real network_geography entries + _NON_REZ_PLACEHOLDER_GEO_IDS
+    assert len(costs_connection) == _EXPECTED_COSTS_CONNECTION_ROWS_75[granularity]
+    assert set(costs_connection["geo_id"]) <= (
+        set(geo["geo_id"]) | _NON_REZ_PLACEHOLDER_GEO_IDS
+    )
 
     # custom_constraints — written only at sub_regions. Detailed content is
     # covered by test_custom_constraints_from_plexos.py; here we assert the CLI

--- a/tests/test_templater/test_create_ispypsa_inputs_template.py
+++ b/tests/test_templater/test_create_ispypsa_inputs_template.py
@@ -62,13 +62,14 @@ def _stub_custom_constraints_tables() -> dict[str, pd.DataFrame]:
 def _new_entrant_property_tables(csv_str_to_df) -> dict[str, pd.DataFrame]:
     """Per-technology property tables the new_entrant templater merges.
 
-    Covers the generator technologies used across the new-format fixtures below
-    (Wind, Large scale Solar PV, OCGT (small GT)) so the property merges resolve.
-    The storage property tables (battery_properties, pumped_hydro_new_entrant_properties)
-    are included too: the fixtures have no storage rows, so the storage subset is empty,
-    but the tables must still be present and non-empty for the merge asserts to pass.
-    Detailed merge behaviour is covered in test_new_entrants.py; here they just
-    need to be present for the wiring to run.
+    Covers every generator/storage technology used across the new-format fixtures
+    below (Wind, Large scale Solar PV, OCGT (small GT), Battery Storage (2hrs
+    storage), Pumped Hydro (24hrs storage)/BOTN - Cethana). technology_specific_lcfs
+    and locational_cost_factors additionally cover every geo_id those fixtures use
+    (Q1, CNSW, SNW, NQ, TAS), including NQ - used by the nem_regions/single_region
+    fixtures to prove a real cross-region merge (see the comments there). Detailed
+    merge behaviour is covered in test_new_entrants.py; here they just need to be
+    present for the wiring to run.
     """
     return {
         "fixed_opex_new_entrants": csv_str_to_df("""
@@ -76,6 +77,7 @@ def _new_entrant_property_tables(csv_str_to_df) -> dict[str, pd.DataFrame]:
             Wind,                           20.0,                     $
             Large scale Solar PV,           15.0,                     $
             OCGT (small GT),                17.0,                     $
+            Battery Storage (2hrs storage), 13.5,                     $
             Pumped Hydro (24hrs storage),   78.5,                     $
             BOTN - Cethana,                 78.5,                     $
         """),
@@ -90,6 +92,7 @@ def _new_entrant_property_tables(csv_str_to_df) -> dict[str, pd.DataFrame]:
             Wind,                           5,                      30
             Large scale Solar PV,           25,                     30
             OCGT (small GT),                25,                     40
+            Battery Storage (2hrs storage), 20,                     20
             Pumped Hydro (24hrs storage),   40,                     90
             BOTN - Cethana,                 40,                     90
         """),
@@ -104,6 +107,7 @@ def _new_entrant_property_tables(csv_str_to_df) -> dict[str, pd.DataFrame]:
             Wind,                           0.0
             Large scale Solar PV,           0.0
             OCGT (small GT),                50.0
+            Battery Storage (2hrs storage), 0.0
             Pumped Hydro (24hrs storage),   40.0
             BOTN - Cethana,                 40.0
         """),
@@ -117,17 +121,19 @@ def _new_entrant_property_tables(csv_str_to_df) -> dict[str, pd.DataFrame]:
             BOTN - Cethana - 20h,          20,                       80
         """),
         "technology_specific_lcfs": csv_str_to_df("""
-            Cost zone / REZ ID, REZ name / Description, Wind,           Large scale Solar PV, OCGT (small GT), Pumped Hydro (24hrs storage), BOTN - Cethana
-            Q1,                 Far North QLD,          1.05,           1.08,                 Not Applicable,  Not Applicable,               Not Applicable
-            CNSW,               Subregional Ref Node,   Not Applicable, Not Applicable,       1.04,            Not Applicable,               Not Applicable
-            SNW,                Subregional Ref Node,   Not Applicable, Not Applicable,       1.00,            Not Applicable,               Not Applicable
-            TAS,                Subregional Ref Node,   Not Applicable, Not Applicable,       Not Applicable,  1.0469,                       100
+            Cost zone / REZ ID, REZ name / Description, Wind,           Large scale Solar PV, OCGT (small GT), Battery Storage (2hrs storage), Pumped Hydro (24hrs storage), BOTN - Cethana
+            Q1,                 Far North QLD,          1.05,           1.08,                 Not Applicable,  Not Applicable,                 Not Applicable,               Not Applicable
+            CNSW,               Subregional Ref Node,   Not Applicable, Not Applicable,       1.04,            1.03,                           Not Applicable,               Not Applicable
+            SNW,                Subregional Ref Node,   Not Applicable, Not Applicable,       1.00,            1.01,                           Not Applicable,               Not Applicable
+            NQ,                 Subregional Ref Node,   Not Applicable, Not Applicable,       1.02,            1.02,                           Not Applicable,               Not Applicable
+            TAS,                Subregional Ref Node,   Not Applicable, Not Applicable,       Not Applicable,  Not Applicable,                 1.0469,                       100
         """),
         "locational_cost_factors": csv_str_to_df("""
             Cost zone / REZ ID, O&M costs 3
             Q1,                 122.0
             CNSW,               110.0
             SNW,                100.0
+            NQ,                 105.0
             TAS,                100.0
         """),
     }
@@ -306,12 +312,12 @@ def test_create_ispypsa_inputs_template_new_format(csv_str_to_df):
         IBR,    10
     """)
     new_entrants_summary = csv_str_to_df("""
-        IASR ID / DLT names,    Technology Type,                Fuel type,  Fuel cost mapping,  REZ ID,         Sub-region, Regional build cost zone
-        Q1_WH_Far North QLD,    Wind,                           Wind,       Wind,               Q1,             NQ,         Q1
-        Q1_SAT_Far North QLD,   Large scale Solar PV,           Solar,      Solar,              Q1,             NQ,         Q1
-        CNSW OCGT Small,        OCGT (small GT),                Gas,        NSW new OCGT,       Not Applicable, CNSW,       CNSW
-        SNW OCGT Small,         OCGT (small GT),                Gas,        NSW new OCGT,       Not Applicable, SNW,        SNW
-        BOTN - Cethana - 20h,   Pumped Hydro (24hrs storage),   Water,      Hydro,              Not Applicable, TAS,        TAS
+        IASR ID / DLT names,    Technology Type,                Fuel type,  REZ ID,         Sub-region, Regional build cost zone
+        Q1_WH_Far North QLD,    Wind,                           Wind,       Q1,             NQ,         Q1
+        Q1_SAT_Far North QLD,   Large scale Solar PV,           Solar,      Q1,             NQ,         Q1
+        CNSW OCGT Small,        OCGT (small GT),                Gas,        Not Applicable, CNSW,       CNSW
+        SNW OCGT Small,         OCGT (small GT),                Gas,        Not Applicable, SNW,        SNW
+        BOTN - Cethana - 20h,   Pumped Hydro (24hrs storage),   Water,      Not Applicable, TAS,        TAS
     """)
 
     with (
@@ -402,6 +408,50 @@ def test_create_ispypsa_inputs_template_new_format(csv_str_to_df):
     assert set(costs_connection["geo_id"]) == {"Q1", "CNSW", "SNW"}
     assert len(costs_connection) == 8
 
+    # At sub_regions, geo_id collapse is a no-op: one row per new-entrant summary
+    # row. Detailed collapse behaviour is covered by test_new_entrants.py.
+    generators_new_entrant = result["generators_new_entrant"]
+    assert set(generators_new_entrant.columns) == {
+        "name",
+        "technology",
+        "resource_type",
+        "geo_id",
+        "fuel_type",
+        "fom",
+        "vom",
+        "lcf_build",
+        "lcf_om",
+        "lifetime_technical",
+        "lifetime_economic",
+        "heat_rate",
+        "minimum_stable_level",
+    }
+    # Wind + Large scale Solar PV (both Q1) + CNSW OCGT Small + SNW OCGT Small.
+    assert set(generators_new_entrant["geo_id"]) == {"Q1", "CNSW", "SNW"}
+    assert len(generators_new_entrant) == 4
+
+    storage_new_entrant = result["storage_new_entrant"]
+    assert set(storage_new_entrant.columns) == {
+        "name",
+        "technology",
+        "geo_id",
+        "fuel_type",
+        "storage_hours",
+        "fom",
+        "efficiency_charge",
+        "efficiency_discharge",
+        "soc_max",
+        "soc_min",
+        "minimum_stable_level",
+        "lcf_build",
+        "lcf_om",
+        "lifetime_technical",
+        "lifetime_economic",
+        "degradation_annual",
+    }
+    # BOTN - Cethana (Pumped Hydro), the only storage row in the fixture.
+    assert len(storage_new_entrant) == 1
+
     # Custom-constraints tables are spliced into the output via
     # template.update(template_custom_constraints_from_plexos(...)). The
     # templater is mocked with _stub_custom_constraints_tables (full content is
@@ -439,6 +489,7 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
         Queensland,       Southern Queensland (SQ),        South Pine 275 kV
         New South Wales,  Central New South Wales (CNSW),  Wellington 330 kV
         New South Wales,  Northern NSW (NNSW),             Armidale 330 kV
+        New South Wales,  Southern NSW (SNW),              Lower Tumut 330 kV
     """)
     renewable_energy_zones = csv_str_to_df("""
         ID,   Name,               NEM region,  ISP sub-region
@@ -502,12 +553,16 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
         IBR,    10
     """)
     new_entrants_summary = csv_str_to_df("""
-        IASR ID / DLT names,    Technology Type,                Fuel type,  Fuel cost mapping,  REZ ID,         Sub-region, Regional build cost zone
-        Q1_WH_Far North QLD,    Wind,                           Wind,       Wind,               Q1,             NQ,         Q1
-        Q1_SAT_Far North QLD,   Large scale Solar PV,           Solar,      Solar,              Q1,             NQ,         Q1
-        CNSW OCGT Small,        OCGT (small GT),                Gas,        NSW new OCGT,       Not Applicable, CNSW,       CNSW
-        SNW OCGT Small,         OCGT (small GT),                Gas,        NSW new OCGT,       Not Applicable, SNW,        SNW
-        BOTN - Cethana - 20h,   Pumped Hydro (24hrs storage),   Water,      Hydro,              Not Applicable, TAS,        TAS
+        IASR ID / DLT names,    Technology Type,                Fuel type,  REZ ID,         Sub-region, Regional build cost zone
+        Q1_WH_Far North QLD,    Wind,                           Wind,       Q1,             NQ,         Q1
+        Q1_SAT_Far North QLD,   Large scale Solar PV,           Solar,      Q1,             NQ,         Q1
+        CNSW OCGT Small,        OCGT (small GT),                Gas,        Not Applicable, CNSW,       CNSW
+        SNW OCGT Small,         OCGT (small GT),                Gas,        Not Applicable, SNW,        SNW
+        NQ OCGT Small,          OCGT (small GT),                Gas,        Not Applicable, NQ,         NQ
+        CNSW Battery - 2h,      Battery Storage (2hrs storage), Battery,    Not Applicable, CNSW,       CNSW
+        SNW Battery - 2h,       Battery Storage (2hrs storage), Battery,    Not Applicable, SNW,        SNW
+        NQ Battery - 2h,        Battery Storage (2hrs storage), Battery,    Not Applicable, NQ,         NQ
+        Q1 Battery - 2h,        Battery Storage (2hrs storage), Battery,    Q1,             NQ,         Q1
     """)
 
     with (
@@ -587,6 +642,15 @@ def test_create_ispypsa_inputs_template_new_format_nem_regions(csv_str_to_df):
     assert set(costs_connection["geo_id"]) == {"Q1", "NSW"}
     assert len(costs_connection) == 6
 
+    # REZ rows are untouched, subregions in same region collapse:
+    generators_new_entrant = result["generators_new_entrant"]
+    assert set(generators_new_entrant["geo_id"]) == {"Q1", "NSW", "QLD"}
+    assert len(generators_new_entrant) == 4
+
+    # REZ rows are untouched, subregions in same region collapse:
+    storage_new_entrant = result["storage_new_entrant"]
+    assert len(storage_new_entrant) == 3
+
     # Custom constraints from PLEXOS are sub-regional export limits with no
     # meaningful representation once sub-regions are collapsed, so the templater
     # skips them at nem_regions granularity. The mock turns a regression in that
@@ -605,6 +669,7 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
         Queensland,       Northern Queensland (NQ),        Ross 275 kV
         Queensland,       Central Queensland (CQ),         Stanwell 275 kV
         New South Wales,  Central New South Wales (CNSW),  Wellington 330 kV
+        New South Wales,  Southern NSW (SNW),              Lower Tumut 330 kV
     """)
     renewable_energy_zones = csv_str_to_df("""
         ID,   Name,               NEM region,  ISP sub-region
@@ -659,12 +724,16 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
         IBR,    10
     """)
     new_entrants_summary = csv_str_to_df("""
-        IASR ID / DLT names,    Technology Type,                Fuel type,  Fuel cost mapping,  REZ ID,         Sub-region, Regional build cost zone
-        Q1_WH_Far North QLD,    Wind,                           Wind,       Wind,               Q1,             NQ,         Q1
-        Q1_SAT_Far North QLD,   Large scale Solar PV,           Solar,      Solar,              Q1,             NQ,         Q1
-        CNSW OCGT Small,        OCGT (small GT),                Gas,        NSW new OCGT,       Not Applicable, CNSW,       CNSW
-        SNW OCGT Small,         OCGT (small GT),                Gas,        NSW new OCGT,       Not Applicable, SNW,        SNW
-        BOTN - Cethana - 20h,   Pumped Hydro (24hrs storage),   Water,      Hydro,              Not Applicable, TAS,        TAS
+        IASR ID / DLT names,    Technology Type,                Fuel type,  REZ ID,         Sub-region, Regional build cost zone
+        Q1_WH_Far North QLD,    Wind,                           Wind,       Q1,             NQ,         Q1
+        Q1_SAT_Far North QLD,   Large scale Solar PV,           Solar,      Q1,             NQ,         Q1
+        CNSW OCGT Small,        OCGT (small GT),                Gas,        Not Applicable, CNSW,       CNSW
+        SNW OCGT Small,         OCGT (small GT),                Gas,        Not Applicable, SNW,        SNW
+        NQ OCGT Small,          OCGT (small GT),                Gas,        Not Applicable, NQ,         NQ
+        CNSW Battery - 2h,      Battery Storage (2hrs storage), Battery,    Not Applicable, CNSW,       CNSW
+        SNW Battery - 2h,       Battery Storage (2hrs storage), Battery,    Not Applicable, SNW,        SNW
+        NQ Battery - 2h,        Battery Storage (2hrs storage), Battery,    Not Applicable, NQ,         NQ
+        Q1 Battery - 2h,        Battery Storage (2hrs storage), Battery,    Q1,             NQ,         Q1
     """)
 
     with (
@@ -739,6 +808,15 @@ def test_create_ispypsa_inputs_template_new_format_single_region(csv_str_to_df):
     # [(2 VRE x 1 REZ) + (1 non-VRE x NEM)] x 2 years
     assert set(connection_costs["geo_id"]) == {"Q1", "NEM"}
     assert len(connection_costs) == 6
+
+    # REZ rows untouched, everything else collapses to 'NEM' geo_id
+    generators_new_entrant = result["generators_new_entrant"]
+    assert set(generators_new_entrant["geo_id"]) == {"Q1", "NEM"}
+    assert len(generators_new_entrant) == 3
+
+    # REZ rows untouched, everything else collapses to 'NEM' geo_id
+    storage_new_entrant = result["storage_new_entrant"]
+    assert len(storage_new_entrant) == 2
 
     # Custom constraints from PLEXOS are sub-regional export limits with no
     # meaningful representation at single_region, so the templater skips them.

--- a/tests/test_templater/test_new_entrants.py
+++ b/tests/test_templater/test_new_entrants.py
@@ -9,7 +9,9 @@ from ispypsa.templater.new_entrants import (
     _add_resource_type,
     _assert_botn_technology_expected,
     _assert_build_cost_zone_matches_geo_id,
+    _assert_no_unexpected_duplicate_options,
     _assert_table_valid,
+    _collapse_geo_id_to_granularity,
     _derive_phes_symmetric_efficiency,
     _group_by_source_key,
     _merge_lcf_build,
@@ -27,16 +29,24 @@ from ispypsa.templater.new_entrants import (
 
 # --- orchestrators ---
 
+# A stand-in for tests where sub_regional_geography's content doesn't matter - e.g.
+# regional_granularity="sub_regions" is a no-op in the collapse step, so it's never
+# read at all; or the frame being collapsed is itself empty, so nothing ever gets
+# looked up in it. See _collapse_geo_id_to_granularity.
+_UNUSED_SUB_REGIONAL_GEOGRAPHY = pd.DataFrame(
+    columns=["geo_id", "geo_type", "region_id"]
+)
+
 
 def test_template_generators_new_entrant(csv_str_to_df):
     # Wiring check only (per-helper behaviour is covered below): storage is dropped,
     # and the identity + property columns are produced, one row per generating unit.
     # Detailed content is covered by the per-helper tests.
     new_entrants_summary = csv_str_to_df("""
-        IASR ID / DLT names,  Technology Type,                Fuel type,  Fuel cost mapping,  REZ ID,         Sub-region, Regional build cost zone
-        Q1_WH_Far North QLD,  Wind,                           Wind,       Wind,               Q1,             NQ,         Q1
-        NQ OCGT Small,        OCGT (small GT),                Gas,        QLD new OCGT,       Not Applicable, NQ,         NQ
-        NQ Battery 2hrs,      Battery Storage (2hrs storage), Battery,    Battery,            Not Applicable, NQ,         NQ
+        IASR ID / DLT names,  Technology Type,                Fuel type,  REZ ID,         Sub-region, Regional build cost zone
+        Q1_WH_Far North QLD,  Wind,                           Wind,       Q1,             NQ,         Q1
+        NQ OCGT Small,        OCGT (small GT),                Gas,        Not Applicable, NQ,         NQ
+        NQ Battery 2hrs,      Battery Storage (2hrs storage), Battery,    Not Applicable, NQ,         NQ
     """)
     iasr_tables = {
         "new_entrants_summary": new_entrants_summary,
@@ -77,7 +87,9 @@ def test_template_generators_new_entrant(csv_str_to_df):
         """),
     }
 
-    result = _template_generators_new_entrant(iasr_tables)
+    result = _template_generators_new_entrant(
+        iasr_tables, "sub_regions", _UNUSED_SUB_REGIONAL_GEOGRAPHY
+    )
 
     # storage row dropped -> 2 gen rows; identity + property columns produced in order
     assert (
@@ -140,19 +152,21 @@ def test_template_storage_new_entrant(csv_str_to_df):
     # storage unit (battery + PHES) is returned. Detailed content is covered by the
     # per-helper tests.
     new_entrants_summary = csv_str_to_df("""
-        IASR ID / DLT names,            Technology Type,                 Fuel type,  Fuel cost mapping,  REZ ID,         Sub-region, Regional build cost zone
-        Q1_WH_Far North QLD,            Wind,                            Wind,       Wind,               Q1,             NQ,         Q1
-        NQ OCGT Small,                  OCGT (small GT),                 Gas,        QLD new OCGT,       Not Applicable, NQ,         NQ
-        NQ Battery 2hrs,                Battery Storage (2hrs storage),  Battery,    Battery,            N3,             NQ,         N3
-        NQ Battery - Distributed,       Distributed Resources Batteries, Battery,    Battery,            Not Applicable, NQ,         NQ
-        BOTN - Cethana - 20h,           Pumped Hydro (24hrs storage),    Water,      Hydro,              Not Applicable, NQ,         NQ
+        IASR ID / DLT names,            Technology Type,                 Fuel type,  REZ ID,         Sub-region, Regional build cost zone
+        Q1_WH_Far North QLD,            Wind,                            Wind,       Q1,             NQ,         Q1
+        NQ OCGT Small,                  OCGT (small GT),                 Gas,        Not Applicable, NQ,         NQ
+        NQ Battery 2hrs,                Battery Storage (2hrs storage),  Battery,    N3,             NQ,         N3
+        NQ Battery - Distributed,       Distributed Resources Batteries, Battery,    Not Applicable, NQ,         NQ
+        BOTN - Cethana - 20h,           Pumped Hydro (24hrs storage),    Water,      Not Applicable, NQ,         NQ
     """)
     iasr_tables = {
         "new_entrants_summary": new_entrants_summary,
         **_storage_property_tables(csv_str_to_df),
     }
 
-    result = _template_storage_new_entrant(iasr_tables)
+    result = _template_storage_new_entrant(
+        iasr_tables, "sub_regions", _UNUSED_SUB_REGIONAL_GEOGRAPHY
+    )
 
     # generator rows dropped -> 3 of 5 rows survive; identity + property columns in order
     assert list(result.columns) == _STORAGE_IDENTITY_COLUMNS + _STORAGE_PROPERTY_COLUMNS
@@ -527,6 +541,184 @@ def test_set_geo_id_empty_input(csv_str_to_df):
         technology, REZ ID, Sub-region, geo_id
     """)
     pd.testing.assert_frame_equal(result, expected, check_dtype=False)
+
+
+# --- _collapse_geo_id_to_granularity ---
+
+
+def test_collapse_geo_id_to_granularity_sub_regions_is_noop(csv_str_to_df):
+    # sub_regions is already the finest granularity - returned as-is.
+    new_entrants = csv_str_to_df("""
+        name,            technology, geo_id, value
+        CNSW OCGT Small, OCGT,       CNSW,   104.0
+        Q1_WH,           Wind,       Q1,     999.0
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        CNSW,       subregion,      NSW
+        Q1,         rez,            QLD
+    """)
+
+    result = _collapse_geo_id_to_granularity(
+        new_entrants,
+        "sub_regions",
+        sub_regional_geography,
+        ["technology"],
+        ["value"],
+    )
+
+    pd.testing.assert_frame_equal(result, new_entrants)
+
+
+def test_collapse_geo_id_to_granularity_averages_across_sub_regions(csv_str_to_df):
+    # NSW's average must be the plain mean of its two sub-regions' values (102.0),
+    # each counted once. The REZ row (Q1) is untouched by the collapse regardless
+    # of granularity. BOTN - Cethana retains original name.
+    new_entrants = csv_str_to_df("""
+        name,                   technology,     geo_id, value
+        CNSW OCGT Small,        OCGT,           CNSW,   104.0
+        SNW OCGT Small,         OCGT,           SNW,    100.0
+        Q1_WH,                  Wind,           Q1,     999.0
+        BOTN - Cethana - 20h,   BOTN - Cethana, TAS,    100.0
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        CNSW,       subregion,      NSW
+        SNW,        subregion,      NSW
+        Q1,         rez,            QLD
+        TAS,        subregion,      TAS
+    """)
+
+    result = _collapse_geo_id_to_granularity(
+        new_entrants,
+        "nem_regions",
+        sub_regional_geography,
+        ["technology"],
+        ["value"],
+    )
+
+    expected = csv_str_to_df("""
+        name,                   technology,     geo_id, value
+        Q1_WH,                  Wind,           Q1,     999.0
+        NSW OCGT,               OCGT,           NSW,    102.0
+        BOTN - Cethana - 20h,   BOTN - Cethana, TAS,    100.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values("technology").reset_index(drop=True),
+        expected.sort_values("technology").reset_index(drop=True),
+    )
+
+
+def test_collapse_geo_id_to_granularity_drops_known_duplicate_before_averaging(
+    csv_str_to_df,
+):
+    # CNSW has a known duplicate build option ("WOO OCGT Small", alongside "CNSW
+    # OCGT Small" - see _KNOWN_DUPLICATE_SUBREGION_OPTIONS)
+    new_entrants = csv_str_to_df("""
+        name,            technology, geo_id, value
+        CNSW OCGT Small, OCGT,       CNSW,   104.0
+        WOO OCGT Small,  OCGT,       CNSW,   104.0
+        SNW OCGT Small,  OCGT,       SNW,    100.0
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        CNSW,       subregion,      NSW
+        SNW,        subregion,      NSW
+    """)
+
+    result = _collapse_geo_id_to_granularity(
+        new_entrants,
+        "nem_regions",
+        sub_regional_geography,
+        ["technology"],
+        ["value"],
+    )
+
+    expected = csv_str_to_df("""
+        name,     technology, geo_id, value
+        NSW OCGT, OCGT,       NSW,    102.0
+    """)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_collapse_geo_id_to_granularity_raises_on_unexpected_duplicate(csv_str_to_df):
+    # Two DIFFERENTLY-named rows sharing (technology, geo_id) that ISN'T the known
+    # WOO case must raise rather than silently skew the average.
+    new_entrants = csv_str_to_df("""
+        name,             technology, geo_id, value
+        CNSW OCGT Small,  OCGT,       CNSW,   104.0
+        ANOTHER OCGT,     OCGT,       CNSW,   200.0
+        SNW OCGT Small,   OCGT,       SNW,    100.0
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        CNSW,       subregion,      NSW
+        SNW,        subregion,      NSW
+    """)
+
+    with pytest.raises(ValueError, match="Unexpected duplicate"):
+        _collapse_geo_id_to_granularity(
+            new_entrants,
+            "nem_regions",
+            sub_regional_geography,
+            ["technology"],
+            ["value"],
+        )
+
+
+def test_collapse_geo_id_to_granularity_single_region_maps_to_nem(csv_str_to_df):
+    # Sub-regions in different NEM regions (NSW, TAS) all collapse to geo_id="NEM".
+    # BOTN keeps name but geo_id still set to "NEM".
+    new_entrants = csv_str_to_df("""
+        name,                   technology,     geo_id, value
+        CNSW OCGT Small,        OCGT,           CNSW,   104.0
+        TAS OCGT Small,         OCGT,           TAS,    108.0
+        BOTN - Cethana - 20h,   BOTN - Cethana, TAS,    100.0
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        CNSW,       subregion,      NSW
+        TAS,        subregion,      TAS
+    """)
+
+    result = _collapse_geo_id_to_granularity(
+        new_entrants,
+        "single_region",
+        sub_regional_geography,
+        ["technology"],
+        ["value"],
+    )
+
+    expected = csv_str_to_df("""
+        name,                   technology,     geo_id, value
+        NEM OCGT,               OCGT,           NEM,    106.0
+        BOTN - Cethana - 20h,   BOTN - Cethana, NEM,    100.0
+    """)
+    pd.testing.assert_frame_equal(
+        result.sort_values("name").reset_index(drop=True),
+        expected.sort_values("name").reset_index(drop=True),
+    )
+
+
+def test_collapse_geo_id_to_granularity_empty_input(csv_str_to_df):
+    new_entrants = csv_str_to_df("""
+        name,   technology,     geo_id,     value
+    """)
+    sub_regional_geography = csv_str_to_df("""
+        geo_id,     geo_type,       region_id
+        CNSW,       subregion,      NSW
+        Q1,         rez,            QLD
+    """)
+
+    result = _collapse_geo_id_to_granularity(
+        new_entrants,
+        "nem_regions",
+        sub_regional_geography,
+        ["technology"],
+        ["value"],
+    )
+
+    pd.testing.assert_frame_equal(result, new_entrants)
 
 
 # --- _add_resource_type (generator-specific) ---

--- a/tests/test_templater/test_new_entrants.py
+++ b/tests/test_templater/test_new_entrants.py
@@ -9,7 +9,6 @@ from ispypsa.templater.new_entrants import (
     _add_resource_type,
     _assert_botn_technology_expected,
     _assert_build_cost_zone_matches_geo_id,
-    _assert_no_unexpected_duplicate_options,
     _assert_table_valid,
     _collapse_geo_id_to_granularity,
     _derive_phes_symmetric_efficiency,
@@ -607,63 +606,6 @@ def test_collapse_geo_id_to_granularity_averages_across_sub_regions(csv_str_to_d
         result.sort_values("technology").reset_index(drop=True),
         expected.sort_values("technology").reset_index(drop=True),
     )
-
-
-def test_collapse_geo_id_to_granularity_drops_known_duplicate_before_averaging(
-    csv_str_to_df,
-):
-    # CNSW has a known duplicate build option ("WOO OCGT Small", alongside "CNSW
-    # OCGT Small" - see _KNOWN_DUPLICATE_SUBREGION_OPTIONS)
-    new_entrants = csv_str_to_df("""
-        name,            technology, geo_id, value
-        CNSW OCGT Small, OCGT,       CNSW,   104.0
-        WOO OCGT Small,  OCGT,       CNSW,   104.0
-        SNW OCGT Small,  OCGT,       SNW,    100.0
-    """)
-    sub_regional_geography = csv_str_to_df("""
-        geo_id,     geo_type,       region_id
-        CNSW,       subregion,      NSW
-        SNW,        subregion,      NSW
-    """)
-
-    result = _collapse_geo_id_to_granularity(
-        new_entrants,
-        "nem_regions",
-        sub_regional_geography,
-        ["technology"],
-        ["value"],
-    )
-
-    expected = csv_str_to_df("""
-        name,     technology, geo_id, value
-        NSW OCGT, OCGT,       NSW,    102.0
-    """)
-    pd.testing.assert_frame_equal(result, expected)
-
-
-def test_collapse_geo_id_to_granularity_raises_on_unexpected_duplicate(csv_str_to_df):
-    # Two DIFFERENTLY-named rows sharing (technology, geo_id) that ISN'T the known
-    # WOO case must raise rather than silently skew the average.
-    new_entrants = csv_str_to_df("""
-        name,             technology, geo_id, value
-        CNSW OCGT Small,  OCGT,       CNSW,   104.0
-        ANOTHER OCGT,     OCGT,       CNSW,   200.0
-        SNW OCGT Small,   OCGT,       SNW,    100.0
-    """)
-    sub_regional_geography = csv_str_to_df("""
-        geo_id,     geo_type,       region_id
-        CNSW,       subregion,      NSW
-        SNW,        subregion,      NSW
-    """)
-
-    with pytest.raises(ValueError, match="Unexpected duplicate"):
-        _collapse_geo_id_to_granularity(
-            new_entrants,
-            "nem_regions",
-            sub_regional_geography,
-            ["technology"],
-            ["value"],
-        )
 
 
 def test_collapse_geo_id_to_granularity_single_region_maps_to_nem(csv_str_to_df):


### PR DESCRIPTION
Adds functionality to collapse (aggregate) new entrant technologies to the model config's `regional_granularity`.

Changes live here:

```
src/ispypsa/templater/
├── new_entrants.py              ← _collapse_geo_id_to_granularity + orchestrators calling it as their final step
├── create_template.py           ← generators/storage_new_entrant + costs_connection now real template outputs
├── geography.py                 ← _build_geo_region_lookup, deduplicated here
└── transmission.py              ← ...(from here), now imports from geography.py

src/ispypsa/validation/schemas/
├── generators_new_entrant.yaml  ← drops fuel_price_mapping (see below) + LCF source table fix
└── storage_new_entrant.yaml     ← same LCF source table fix

src/ispypsa/iasr_table_caching/local_cache.py
                                 ← registers technology_specific_lcfs/locational_cost_factors (missed in prev PR)
```

## Notes

- **The "WOO" duplicate sub-region option is an explicit named case.** Real 7.5 data has one duplicate build option per sub-region for four gas technologies (e.g. "WOO OCGT Small" alongside "CNSW OCGT Small"). Rather than a
  weighted average that implicitly compensates for this, it drops the known rows by name and `_assert_no_unexpected_duplicate_options` raises on any other repeat (unexpected). Documented in comments on Open-ISP/ISPyPSA#131.
- **`fuel_price_mapping` dropped from `generators_new_entrant` entirely**, rather than carried through the collapse. It's not needed until fuel price templating exists - plan is to match fuel prices via `geo_id` +`technology` against a redesigned `costs_fuel_prices` table, now made easier/a more viable option with the planned wild-card schema thing. Two schemas will need matching updates when that happens: `costs_fuel_prices.yaml` and `generators_existing_planned.yaml`.
- **Merged rows are named `"{geo_id} {technology}"`, except BOTN - Cethana**, which keeps its real name.

### Follow-ups for later

- `costs_fuel_prices.yaml` / `generators_existing_planned.yaml` fuel-price-mapping rework (might also rely a bit on #126 and the wildcard handling to properly settle this)
- Pre-existing gap, not fixed here: `N0`/`V0` ("Non-REZ" IDs for NSW/VIC) are used as `geo_id` but never appear in `renewable_energy_zones`, so they're absent from `network_geography` at every granularity — tracked as Open-ISP/ISPyPSA#133, set out as a known exception in the CLI test.